### PR TITLE
Handle errors when auto is specified and the number of cpus cannot be detected.

### DIFF
--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -4,8 +4,15 @@ import pytest
 
 def parse_numprocesses(s):
     if s == 'auto':
-        import multiprocessing
-        return multiprocessing.cpu_count()
+        try:
+            from os import cpu_count
+        except ImportError:
+            from multiprocessing import cpu_count
+        try:
+            n = cpu_count()
+        except NotImplementedError:
+            return 1
+        return n if n else 1
     else:
         return int(s)
 


### PR DESCRIPTION
~~```os.cpu_count()``` is the new way to ask for the number of cpus provided by the system in python 3.
I also added a bit of error handling since ```os.cpu_count()``` may return None if the information is not available and ```multiprocessing.cpu_count()``` may raise ```NotImplementedError```.~~
I found out that multiprocessing.cpu_count() reuses os.cpu_count() so I rebased this PR to just add some error handling for the case where cpu count cannot be determined.