### PR TITLE
Do a better job parallelizing the inital batch of tests

### DIFF
--- a/xdist/dsession.py
+++ b/xdist/dsession.py
@@ -373,10 +373,11 @@ class LoadScheduling:
         initial_batch = max(len(self.pending) // 4,
                             2 * len(self.nodes))
 
-        # distribute tests round-robin up to the batch size (or until we run out)
+        # distribute tests round-robin up to the batch size
+        # (or until we run out)
         nodes = itertools.cycle(self.nodes)
         for i in range(initial_batch):
-            self._send_tests(nodes.next(), 1)
+            self._send_tests(next(nodes), 1)
 
         if not self.pending:
             # initial distribution sent all tests, start node shutdown

--- a/xdist/dsession.py
+++ b/xdist/dsession.py
@@ -375,7 +375,7 @@ class LoadScheduling:
 
         # distribute tests round-robin up to the batch size (or until we run out)
         nodes = itertools.cycle(self.nodes)
-        for i in xrange(initial_batch):
+        for i in range(initial_batch):
             self._send_tests(nodes.next(), 1)
 
         if not self.pending:

--- a/xdist/slavemanage.py
+++ b/xdist/slavemanage.py
@@ -207,12 +207,17 @@ class SlaveController(object):
         self.config = config
         self.slaveinput = {'slaveid': gateway.id}
         self._down = False
+        self._shutdown_sent = False
         self.log = py.log.Producer("slavectl-%s" % gateway.id)
         if not self.config.option.debug:
             py.log.setconsumer(self.log._keywords, None)
 
     def __repr__(self):
         return "<%s %s>" % (self.__class__.__name__, self.gateway.id,)
+
+    @property
+    def shutting_down(self):
+        return self._down or self._shutdown_sent
 
     def setup(self):
         self.log("setting up slave session")
@@ -256,6 +261,7 @@ class SlaveController(object):
                 self.sendcommand("shutdown")
             except IOError:
                 pass
+            self._shutdown_sent = True
 
     def sendcommand(self, name, **kwargs):
         """ send a named parametrized command to the other side. """


### PR DESCRIPTION
...when the number of nodes is more than half the number of tests. This makes it
possible, for example, to run all tests in parallel, where previous
the maximum parallelization was half of all tests. This fixes #12.