### PR TITLE
Update travis to use more recent python and pytest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   # some builds that are unnecessary/perceived redundant:
   # py27 and py35 are tested with all pytest versions we declare to support;
   # py26 and py34 only with latest pytest versions.
+  # pytest24,25,26 don't work on py35 due to changes in ast module
   - TESTENV=py26-pytest27
   - TESTENV=py26-pytest28
 
@@ -25,9 +26,6 @@ env:
   - TESTENV=py34-pytest27
   - TESTENV=py34-pytest28
 
-  - TESTENV=py35-pytest24
-  - TESTENV=py35-pytest25
-  - TESTENV=py35-pytest26
   - TESTENV=py35-pytest27
   - TESTENV=py35-pytest28
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-    - '3.5.0b3'
+    - '3.5'
 # command to install dependencies
 install: "pip install -U tox setuptools_scm"
 # # command to run tests
@@ -10,23 +10,30 @@ env:
   - TESTENV=flakes
   - TESTENV=readme
   # matrix was trimmed to skip
-  # some builds that are unnecessary/perceived redundant
-  - TESTENV=py26-pytest24
-  - TESTENV=py26-pytest25
-  - TESTENV=py26-pytest26
+  # some builds that are unnecessary/perceived redundant:
+  # py27 and py35 are tested with all pytest versions we declare to support;
+  # py26 and py34 only with latest pytest versions.
   - TESTENV=py26-pytest27
-  - TESTENV=py33-pytest27
-  - TESTENV=py34-pytest24
-  - TESTENV=py34-pytest25
-  - TESTENV=py34-pytest26
+  - TESTENV=py26-pytest28
+
   - TESTENV=py27-pytest24
   - TESTENV=py27-pytest25
   - TESTENV=py27-pytest26
+  - TESTENV=py27-pytest27
+  - TESTENV=py27-pytest28
 
-  - TESTENV=py27-pytest27-pexpect
-  - TESTENV=py34-pytest27-pexpect
-#  - TESTENV=py35-pytest27
-  - TESTENV=pypy-pytest27
+  - TESTENV=py34-pytest27
+  - TESTENV=py34-pytest28
+
+  - TESTENV=py35-pytest24
+  - TESTENV=py35-pytest25
+  - TESTENV=py35-pytest26
+  - TESTENV=py35-pytest27
+  - TESTENV=py35-pytest28
+
+  - TESTENV=py27-pytest28-pexpect
+  - TESTENV=py34-pytest28-pexpect
+  - TESTENV=pypy-pytest28
 
 script: tox --recreate -e $TESTENV
 

--- a/testing/test_dsession.py
+++ b/testing/test_dsession.py
@@ -277,7 +277,7 @@ def test_report_collection_diff_different():
         ' ccc\n'
         '-YYY')
 
-    msg = report_collection_diff(from_collection, to_collection, 1, 2)
+    msg = report_collection_diff(from_collection, to_collection, '1', '2')
     assert msg == error_message
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-  py{26,33,34,27}-pytest2{4,5,6,7},py{27,34}-pytest27-pexpect,flakes,readme
+  py{26,27,34,35}-pytest2{4,5,6,7,8},py{27,34}-pytest28-pexpect,flakes,readme
 
 
 [testenv]
@@ -10,9 +10,9 @@ deps =
     setuptools_scm # to avoid .eggs
     pytest24: pytest~=2.4.0
     pytest25: pytest~=2.5.0
-
     pytest26: pytest~=2.6.1
     pytest27: pytest~=2.7.2
+    pytest28: pytest~=2.8.3
     pexpect: pexpect
 commands=
   # always clean to avoid code unmarshal mismatch on old python/pytest


### PR DESCRIPTION
- Fix current "python" environment on travis to 3.5
- Updated build matrix to give preference of testing all pytest versions in py27 and py35
- Fix a small regression in `test_report_collection_diff_different`