### PR TITLE
Unit test "auto" cpu detection

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -353,17 +353,6 @@ def test_terminate_on_hangingnode(testdir):
     result.stdout.fnmatch_lines(["*killed*my*", ])
 
 
-def test_auto_detect_cpus(testdir, monkeypatch):
-    import multiprocessing
-    count = multiprocessing.cpu_count()
-    testdir.makeconftest("""
-        def pytest_configure(config):
-            print("numprocesses: (%s)" % config.getoption("numprocesses"))
-    """)
-    result = testdir.runpytest('-n=auto', '-s')
-    result.stdout.fnmatch_lines(["*numprocesses: (%s)*" % count])
-
-
 @pytest.mark.xfail(reason="works if run outside test suite", run=False)
 def test_session_hooks(testdir):
     testdir.makeconftest("""

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -25,6 +25,17 @@ def test_dist_options(testdir):
     assert config.option.dist == "load"
 
 
+def test_auto_detect_cpus(testdir, monkeypatch):
+    import multiprocessing
+    monkeypatch.setattr(multiprocessing, 'cpu_count', lambda: 99)
+
+    config = testdir.parseconfigure("-n2")
+    assert config.getoption('numprocesses') == 2
+
+    config = testdir.parseconfigure("-nauto")
+    assert config.getoption('numprocesses') == 99
+
+
 class TestDistOptions:
     def test_getxspecs(self, testdir):
         config = testdir.parseconfigure("--tx=popen", "--tx", "ssh=xyz")


### PR DESCRIPTION
Use that instead of an acceptance test: on travis it would result in over 16 slaves being spawned,
which caused weird crashes on multiprocessing module during teardown

:sweat: 

Fix #30 