### PR TITLE
Set an environment variable per subprocess

### DIFF
--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -140,6 +140,8 @@ if __name__ == '__channelexec__':
     if sys.version_info[:2] == (3, 2):
         os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
     slaveinput, args, option_dict = channel.receive()
+    os.environ['XDIST_SLAVE_ID'] = slaveinput.get('slaveid', "?")
+
     importpath = os.getcwd()
     sys.path.insert(0, importpath)  # XXX only for remote situations
     os.environ['PYTHONPATH'] = (


### PR DESCRIPTION
This makes it easy to create external resources based on worker ID, e.g. databases.