### PR TITLE
Refactor tox and ci scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,31 +7,28 @@ install: "pip install -U tox setuptools_scm"
 # # command to run tests
 env:
   matrix:
-  - TESTENV=flakes
-  - TESTENV=readme
-  # matrix was trimmed to skip
-  # some builds that are unnecessary/perceived redundant:
-  # py27 and py35 are tested with all pytest versions we declare to support;
-  # py26 and py34 only with latest pytest versions.
-  # pytest24,25,26 don't work on py35 due to changes in ast module
+  # note: please use "tox --listenvs" to populate the build matrix
+  - TESTENV=py26-pytest24
+  - TESTENV=py26-pytest25
+  - TESTENV=py26-pytest26
   - TESTENV=py26-pytest27
   - TESTENV=py26-pytest28
-
   - TESTENV=py27-pytest24
   - TESTENV=py27-pytest25
   - TESTENV=py27-pytest26
   - TESTENV=py27-pytest27
   - TESTENV=py27-pytest28
-
+  - TESTENV=py34-pytest24
+  - TESTENV=py34-pytest25
+  - TESTENV=py34-pytest26
   - TESTENV=py34-pytest27
   - TESTENV=py34-pytest28
-
   - TESTENV=py35-pytest27
   - TESTENV=py35-pytest28
-
   - TESTENV=py27-pytest28-pexpect
-  - TESTENV=py34-pytest28-pexpect
-  - TESTENV=pypy-pytest28
+  - TESTENV=py35-pytest28-pexpect
+  - TESTENV=flakes
+  - TESTENV=readme
 
 script: tox --recreate -e $TESTENV
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,7 @@
-environment:
-  matrix:
-    - PYTHON: "C:\\Python35"
-      TESTENV: "py35"
-
-    - PYTHON: "C:\\Python27"
-      TESTENV: "py27"
-
 install:
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - pip install tox setuptools_scm"
+  - C:\Python35\python -m pip install tox setuptools_scm
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  # Build the compiled extension and run the project tests
-  - tox -e %TESTENV%-pytest27,%TESTENV%-pytest28,readme,flakes
+  - C:\Python35\python -m tox

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -2,8 +2,9 @@ import py
 from xdist.slavemanage import SlaveController, unserialize_report
 from xdist.remote import serialize_report
 import execnet
-queue = py.builtin._tryimport("queue", "Queue")
 import marshal
+
+queue = py.builtin._tryimport("queue", "Queue")
 
 WAIT_TIMEOUT = 10.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,27 @@
 [tox]
+# if you change the envlist, please update .travis.yml file as well
 envlist=
-  py{26,27,34,35}-pytest2{4,5,6,7,8},py{27,34}-pytest28-pexpect,flakes,readme
+  py{26,27,34}-pytest2{4,5,6,7,8}
+  py35-pytest2{7,8}
+  py{27,35}-pytest28-pexpect
+  flakes
+  readme  
 
 
 [testenv]
 changedir=testing
 passenv = USER USERNAME
 deps =
-    pycmd
-    setuptools_scm # to avoid .eggs
-    pytest24: pytest~=2.4.0
-    pytest25: pytest~=2.5.0
-    pytest26: pytest~=2.6.1
-    pytest27: pytest~=2.7.2
-    pytest28: pytest~=2.8.3
-    pexpect: pexpect
+  pycmd
+  setuptools_scm # to avoid .eggs
+  pytest24: pytest~=2.4.0
+  pytest25: pytest~=2.5.0
+  pytest26: pytest~=2.6.1
+  pytest27: pytest~=2.7.2
+  pytest28: pytest~=2.8.3
+  pexpect: pexpect
+platform=
+  pexpect: linux|darwin    
 commands=
   # always clean to avoid code unmarshal mismatch on old python/pytest
   py.cleanup -aq

--- a/xdist/__init__.py
+++ b/xdist/__init__.py
@@ -1,2 +1,3 @@
-__all__ = ['__version__']
 from xdist._version import version as __version__
+
+__all__ = ['__version__']


### PR DESCRIPTION
Make sure a plain `tox`  command (without parameters) works in all platforms without failures, which facilitates making releases using a "devpi upload/test" workflow. I noticed this problem while working on the `1.14` release and using Travis and AppVeyor to test the generated package.

After this changes, a `devpi test` command works as expected in both platforms. Here's the output for a fictional `1.14.1.dev1` package containing this fixes which I uploaded to my staging area:

* [Travis](https://travis-ci.org/nicoddemus/devpi-cloud-tester/builds/105911224)
* [AppVeyor](https://ci.appveyor.com/project/nicoddemus/devpi-cloud-tester/build/1.0.12)
* [Results link on devpi](https://devpi.net/nicoddemus/dev/pytest-xdist/1.14.1.dev1/+toxresults/pytest-xdist-1.14.1.dev1.zip)

Also, make sure we always run all tox environments in the CI: if we leave some of those out, we will only find about a problem with a particular environment when making a release, which is frustrating. Is better to find out problems as early as possible, after all.

Here's a rundown of the contents of this commit:

* Fix small flakes failures
* Limit py35 testing to pytest>=2.7, as pytest<2.7 does not work on py35
* `pexpect` environments only work on Linux platforms and should be skipped on Windows
* Simplify AppVeyor script by running all tox environments: no need to have a build matrix
  because AppVeyor does not execute builds in parallel
* Add all environments to `.travis.yml`, obtained from "tox --listenvs"