### PR TITLE
Cleanly shutdown workers if session should be interrupted

### DIFF
--- a/xdist/dsession.py
+++ b/xdist/dsession.py
@@ -535,6 +535,7 @@ class DSession:
         while not self.session_finished:
             self.loop_once()
             if self.shouldstop:
+                self.triggershutdown()
                 raise Interrupted(str(self.shouldstop))
         return True
 


### PR DESCRIPTION
As discussed in #66

I did verify that even after reverting my changes in `remote.py` (b4a7a1a8) this PR fixes the original problem, but I believe we should keep those changes as well because we don't want an internal error exploding if the master node closes unexpectedly.