### PR TITLE
Add env variables to identify workers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,6 +187,8 @@ at once.   The specifications strings use the `xspec syntax`_.
 
 Identifying the worker process during a test
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
 If you need to determine the identity of a worker process in
 a test or fixture, you may use the ``worker_id`` fixture to do so:
 
@@ -199,6 +201,15 @@ a test or fixture, you may use the ``worker_id`` fixture to do so:
 
 When ``xdist`` is disabled (running with ``-n0`` for example), then
 ``worker_id`` will return ``"master"``.
+
+Additionally, worker processes have the following environment variables
+defined:
+
+* ``PYTEST_XDIST_WORKER``: the name of the worker, e.g., ``"gw2"``.
+* ``PYTEST_XDIST_WORKER_COUNT``: the total number of workers in this session,
+  e.g., ``"4"`` when ``-n 4`` is given in the command-line.
+
+*New in version 1.15.*
 
 Specifying test exec environments in an ini file
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -148,6 +148,8 @@ if __name__ == '__channelexec__':
     os.environ['PYTHONPATH'] = (
         importpath + os.pathsep +
         os.environ.get('PYTHONPATH', ''))
+    os.environ['PYTEST_XDIST_WORKER'] = slaveinput['slaveid']
+    os.environ['PYTEST_XDIST_WORKER_COUNT'] = str(slaveinput['slavecount'])
     # os.environ['PYTHONPATH'] = importpath
     import py
     config = remote_initconfig(option_dict, args)

--- a/xdist/slavemanage.py
+++ b/xdist/slavemanage.py
@@ -205,7 +205,8 @@ class SlaveController(object):
         self.putevent = putevent
         self.gateway = gateway
         self.config = config
-        self.slaveinput = {'slaveid': gateway.id}
+        self.slaveinput = {'slaveid': gateway.id,
+                           'slavecount': len(nodemanager.specs)}
         self._down = False
         self._shutdown_sent = False
         self.log = py.log.Producer("slavectl-%s" % gateway.id)


### PR DESCRIPTION
While we now have the `worker_id` fixture, having environment variables can help in some situations where you don't have easy access to a fixture, for example in some debugging situations.