### PR TITLE
Don't show warning from pytest 3

### DIFF
--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -32,7 +32,7 @@ def pytest_addoption(parser):
     group._addoption(
         '--dist', metavar="distmode",
         action="store", choices=['load', 'each', 'no'],
-        type="choice", dest="dist", default="no",
+        type=str, dest="dist", default="no",
         help=("set mode for distributing tests to exec environments.\n\n"
               "each: send each test to each available environment.\n\n"
               "load: send each test to available environment.\n\n"


### PR DESCRIPTION
Running with py.test 3.0.2 shows:

/usr/lib/python2.7/site-packages/xdist/plugin.py:36: DeprecationWarning: type argument to addoption() is a string 'choice'. For parsearg this is optional and when supplied  should be a type. (options: ('--dist',))
  help=("set mode for distributing tests to exec environments.\n\n"
