### PR TITLE
Fix for eventname test

### DIFF
--- a/xdist/slavemanage.py
+++ b/xdist/slavemanage.py
@@ -292,7 +292,7 @@ class SlaveController(object):
                     self._down = True
                 return
             eventname, kwargs = eventcall
-            if eventname in ("collectionstart"):
+            if eventname in ("collectionstart",):
                 self.log("ignoring %s(%s)" % (eventname, kwargs))
             elif eventname == "slaveready":
                 self.notify_inproc(eventname, node=self, **kwargs)


### PR DESCRIPTION
The eventname is being checked to see if it's a substring of "collectionstart", when I think the intent is to check if it's a member of a set that includes the string "collectionstart". This changes the code to be a one-element tuple instead of a string.