### PR TITLE
Added notes about new pytest_xdist_make_scheduler hook

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,11 @@
 
 - Add ``worker_id`` attribute in the TestReport
 
+- new hook: ``pytest_xdist_make_scheduler(config, log)``, can return custom tests items
+  distribution logic implementation. You can take a look at built-in ``LoadScheduling``
+  and ``EachScheduling`` implementations. Note that required scheduler class public
+  API may change in next ``pytest-xdist`` versions.
+
 1.15.0
 ------
 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -34,6 +34,8 @@ The execution flow is:
    tests and sends them one by one to each **worker** in a round robin
    fashion. The rest of the tests will be distributed later as **workers**
    finish tests (see below).
+
+1. Note that `pytest_xdist_make_scheduler` hook can be used to implement custom tests distribution logic.
    
 1. **workers** re-implement `pytest_runtestloop`: pytest's default implementation
    basically loops over all collected items in the `session` object and executes


### PR DESCRIPTION
According to #89 added notes about new hook and possible scheduler implementations to `CHANGELOG` and `OVERVIEW.md`.