### PR TITLE
Revert PR 125 due to 1.17.0 breakage 

### DIFF
--- a/changelog/157.bugfix
+++ b/changelog/157.bugfix
@@ -1,0 +1,1 @@
+Hot fix release reverting the change introduced by #124, unfortunately it broke a number of test suites so we are reversing this change while we investigate the problem.

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -454,30 +454,9 @@ def test_crashing_item(testdir):
             pass
     """)
     result = testdir.runpytest("-n2", p)
-    result.stdout.fnmatch_lines(
-        ["*crashed*::test_crash*", "*1 failed*1 passed*"])
-
-def test_crashing_item_teardown(testdir):
-    p = testdir.makepyfile("""
-        import py
-        import pytest
-        import os
-        import time
-
-        @pytest.fixture
-        def crash_fixture(request):
-            def kill_me():
-                py.process.kill(os.getpid())
-            request.addfinalizer(kill_me)
-
-        def test_a(crash_fixture):
-            pass
-
-        def test_b():
-            pass
-    """)
-    result = testdir.runpytest("-n1", p)
-    result.stdout.fnmatch_lines(["*crashed*::test_a*", "*1 failed*2 passed*"])
+    result.stdout.fnmatch_lines([
+        "*crashed*test_crash*", "*1 failed*1 passed*"
+    ])
 
 
 def test_skipping(testdir):

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -457,7 +457,6 @@ def test_crashing_item(testdir):
     result.stdout.fnmatch_lines(
         ["*crashed*::test_crash*", "*1 failed*1 passed*"])
 
-
 def test_crashing_item_teardown(testdir):
     p = testdir.makepyfile("""
         import py

--- a/xdist/dsession.py
+++ b/xdist/dsession.py
@@ -660,7 +660,7 @@ class DSession:
         If the node indicates it is finished with a test item, remove
         the item from the pending list in the scheduler.
         """
-        if rep.when == "teardown" or (rep.when == "setup" and not rep.passed):
+        if rep.when == "call" or (rep.when == "setup" and not rep.passed):
             self.sched.mark_test_complete(node, rep.item_index, rep.duration)
         # self.report_line("testreport %s: %s" %(rep.id, rep.status))
         rep.node = node


### PR DESCRIPTION
This PR reverts the commits introduced by #125 because unfortunately it broke a number of test suites.

I think it is better to release a hot-fix reverting this while we investigate the issue better.

I tested this locally with pytest's own suite.

@RonnyPfannschmidt feel free to merge and make a new release if you agree.

cc @reginaldl 

Fix #157 