### PR TITLE
Let setuptools_scm manage the files that go into the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,0 @@
-include CHANGELOG
-include LICENSE 
-include README.txt
-include setup.py
-include tox.ini
-graft testing
-prune .git


### PR DESCRIPTION
As discussed in #161, setuptools_scm will automatically
add all version controlled files to the package, so
MANIFEST.in is no longer needed

Fix #161
