### PR TITLE
add '--numprocesses' as long option for '-n'

### DIFF
--- a/changelog/168.feature
+++ b/changelog/168.feature
@@ -1,0 +1,1 @@
+Add long option `--numprocesses` as alternative for `-n`.

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -20,7 +20,7 @@ def test_dist_options(testdir):
     check_options(config)
     assert config.option.dist == "load"
     assert config.option.tx == ['popen'] * 2
-    config = testdir.parseconfigure("--numprocesses 2")
+    config = testdir.parseconfigure("--numprocesses", "2")
     check_options(config)
     assert config.option.dist == "load"
     assert config.option.tx == ['popen'] * 2

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -20,6 +20,10 @@ def test_dist_options(testdir):
     check_options(config)
     assert config.option.dist == "load"
     assert config.option.tx == ['popen'] * 2
+    config = testdir.parseconfigure("--numprocesses 2")
+    check_options(config)
+    assert config.option.dist == "load"
+    assert config.option.tx == ['popen'] * 2
     config = testdir.parseconfigure("-d")
     check_options(config)
     assert config.option.dist == "load"

--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -20,7 +20,7 @@ def parse_numprocesses(s):
 def pytest_addoption(parser):
     group = parser.getgroup("xdist", "distributed and subprocess testing")
     group._addoption(
-        '-n', dest="numprocesses", metavar="numprocesses",
+        '-n', '--numprocesses', dest="numprocesses", metavar="numprocesses",
         action="store",
         type=parse_numprocesses,
         help="shortcut for '--dist=load --tx=NUM*popen', "


### PR DESCRIPTION
This is more verbose in scripts that run pytest-xdist. It can also help
in some ci-helper scripts like to auto detect if  pytest-xdist should be
installed.

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] Add a new news fragment into the changelog folder, following these guidelines:
  * Name it `$issue_id.$type` for example `588.bug`
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```


