### PR TITLE
Serialization/Deserialization was dropping longrepr.sections

### DIFF
--- a/changelog/pr_171.bugfix
+++ b/changelog/pr_171.bugfix
@@ -1,0 +1,1 @@
+Forgot to serialize and deserialize the longrepr.sections attribute.

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -87,11 +87,14 @@ class TestReportSerialization:
         reports = reprec.getreports("pytest_runtest_logreport")
         assert len(reports) == 3
         initial_failure_report = reports[1]
+        added_section = ('Failure Metadata', str("metadata metadata"), "*")
+        initial_failure_report.longrepr.sections.append(added_section)
         d = serialize_report(initial_failure_report)
         check_marshallable(d)
         processed_report = unserialize_report("testreport", d)
         assert 'Expected Message' \
                in processed_report.longrepr.reprcrash.message
+        assert added_section in processed_report.longrepr.sections
 
     def test_itemreport_outcomes(self, testdir):
         reprec = testdir.inline_runsource("""

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -114,7 +114,8 @@ def serialize_report(rep):
 
         return {
             'reprcrash': reprcrash,
-            'reprtraceback': reprtraceback
+            'reprtraceback': reprtraceback,
+            'sections': rep.longrepr.sections
         }
 
     import py

--- a/xdist/slavemanage.py
+++ b/xdist/slavemanage.py
@@ -359,10 +359,14 @@ def unserialize_report(name, reportdict):
                     unserialized_entries.append(reprentry)
                 reprtraceback['reprentries'] = unserialized_entries
 
-                reportdict['longrepr'] = ReprExceptionInfo(
+                exception_info = ReprExceptionInfo(
                     reprtraceback=ReprTraceback(**reprtraceback),
                     reprcrash=ReprFileLocation(**reprcrash),
                 )
+
+                for section in reportdict['longrepr']['sections']:
+                    exception_info.addsection(*section)
+                reportdict['longrepr'] = exception_info
         return reportdict
 
     if name == "testreport":


### PR DESCRIPTION
This was introduced in PR [164](https://github.com/pytest-dev/pytest-xdist/pull/164). I forgot to serialize/deserialize the sections attribute from ExceptionRepr which is on longrepr. This affects users who append or modify `longrepr.sections` for custom reporting.

Wasn't sure if I should have filed an issue first then a PR. This was a stupid oversight on my part. Sorry for the bug. 

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] Add a *news* file into the `changelog` folder, following these guidelines:
  * Name it `$issue_id.$type` for example `588.bug`
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```


