### PR TITLE
Unserialize reprlocals to a ReprLocal instance

### DIFF
--- a/changelog/176.bugfix
+++ b/changelog/176.bugfix
@@ -1,0 +1,1 @@
+Fix ``ReprLocal`` not being unserialized breaking --showlocals usages.

--- a/xdist/slavemanage.py
+++ b/xdist/slavemanage.py
@@ -329,10 +329,11 @@ class SlaveController(object):
 def unserialize_report(name, reportdict):
     def assembled_report(reportdict):
         from _pytest._code.code import (
+            ReprEntry,
             ReprExceptionInfo,
             ReprFileLocation,
-            ReprEntry,
             ReprFuncArgs,
+            ReprLocals,
             ReprTraceback
         )
         if reportdict['longrepr']:
@@ -343,16 +344,18 @@ def unserialize_report(name, reportdict):
 
                 unserialized_entries = []
                 for entry in reprtraceback['reprentries']:
-                    reprfuncargs, reprfileloc = None, None
+                    reprfuncargs, reprfileloc, reprlocals = None, None, None
                     if entry['reprfuncargs']:
                         reprfuncargs = ReprFuncArgs(**entry['reprfuncargs'])
                     if entry['reprfileloc']:
                         reprfileloc = ReprFileLocation(**entry['reprfileloc'])
+                    if entry['reprlocals']:
+                        reprlocals = ReprLocals(entry['reprlocals']['lines'])
 
                     reprentry = ReprEntry(
                         lines=entry['lines'],
                         reprfuncargs=reprfuncargs,
-                        reprlocals=entry['reprlocals'],
+                        reprlocals=reprlocals,
                         filelocrepr=reprfileloc,
                         style=entry['style']
                     )


### PR DESCRIPTION
This is in reference to issue #176 and a continuation of PR #164 and #171 

I had to instantiate ReprLocals. Added more asserts around comparing the initial report against the result after being serialized, unserialized. 

I think in the initial review @RonnyPfannschmidt mentioned this kind of functionality should me moved in pytest-core. I wholeheartedly agree, since I am terrible at handling it myself. Please be critical of my method since I obviously keep overlooking aspects and introducing new issues. 

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] Add a *news* file into the `changelog` folder, following these guidelines:
  * Name it `$issue_id.$type` for example `588.bug`
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```


