### PR TITLE
Update CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 pytest-xdist 1.18.0 (2017-06-26)
 ================================
 
-- ``pytest-xdist`` now requires pytest 3.0 or later.
+- ``pytest-xdist`` now requires `pytest>=3.0.0`.
 
 Features
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 pytest-xdist 1.18.0 (2017-06-26)
 ================================
 
-- ``pytest-xdist`` now requires `pytest>=3.0.0`.
+- ``pytest-xdist`` now requires ``pytest>=3.0.0``.
 
 Features
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 pytest-xdist 1.18.0 (2017-06-26)
 ================================
 
+- ``pytest-xdist`` now requires pytest 3.0 or later.
+
 Features
 --------
 


### PR DESCRIPTION
Update `1.18.0` entry in CHANGELOG to reflect that `pytest-xdist` now requires `pytest>=3.0.0`.

Thanks for submitting a PR, your contribution is really appreciated!


