### PR TITLE
Removal of unnecessary dependency on py

### DIFF
--- a/changelog/105.bugfix
+++ b/changelog/105.bugfix
@@ -1,0 +1,1 @@
+Removal of unnecessary dependency on incorrect version of py.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         ],
     },
     zip_safe=False,
-    install_requires=['execnet>=1.1', 'pytest>=3.0.0', 'py>=1.4.22'],
+    install_requires=['execnet>=1.1', 'pytest>=3.0.0'],
     setup_requires=['setuptools_scm'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
`pytest-xdist` depends on `pytest>=3`.
`pytest 3.0.0` requires `py>=1.4.29`
and latest pytest requires `py>=1.4.33`.
Thus it is unnecessary for pytest-xdist to include
a requirement on `py>=1.4.22`

Fixes https://github.com/pytest-dev/pytest-xdist/issues/105

----

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] Add a *news* file into the `changelog` folder, following these guidelines:
  * Name it `$issue_id.$type` for example `588.bug`
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```


