### PR TITLE
Fix serialization of native tracebacks

### DIFF
--- a/changelog/196.bugfix
+++ b/changelog/196.bugfix
@@ -1,0 +1,1 @@
+Fix serialization of native tracebacks (``--tb=native``).

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -671,6 +671,20 @@ def test_worker_id_fixture(testdir, n):
         assert worker_ids == set(['gw0', 'gw1'])
 
 
+@pytest.mark.parametrize('tb',
+                         ['auto', 'long', 'short', 'no', 'line', 'native'])
+def test_error_report_styles(testdir, tb):
+    testdir.makepyfile("""
+        import pytest
+        def test_error_report_styles():
+            raise RuntimeError('some failure happened')
+    """)
+    result = testdir.runpytest('-n1', '--tb=%s' % tb)
+    if tb != 'no':
+        result.stdout.fnmatch_lines('*some failure happened*')
+    result.assert_outcomes(failed=1)
+
+
 def test_color_yes_collection_on_non_atty(testdir, request):
     """skip collect progress report when working on non-terminals.
 

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -113,8 +113,9 @@ class TestReportSerialization:
         assert added_section in a.longrepr.sections
 
     def test_reprentries_serialization_170(self, testdir):
+        from _pytest._code.code import ReprEntry
         reprec = testdir.inline_runsource("""
-                            def test_fail():
+                            def test_repr_entry():
                                 x = 0
                                 assert x
                         """, '--showlocals', '-n1')
@@ -128,12 +129,33 @@ class TestReportSerialization:
         a_entries = a.longrepr.reprtraceback.reprentries
         assert rep_entries == a_entries
         for i in range(len(a_entries)):
+            assert isinstance(rep_entries[i], ReprEntry)
             assert rep_entries[i].lines == a_entries[i].lines
             assert rep_entries[i].localssep == a_entries[i].localssep
             assert rep_entries[i].reprfileloc == a_entries[i].reprfileloc
             assert rep_entries[i].reprfuncargs == a_entries[i].reprfuncargs
             assert rep_entries[i].reprlocals == a_entries[i].reprlocals
             assert rep_entries[i].style == a_entries[i].style
+
+    def test_reprentries_serialization_196(self, testdir):
+        from _pytest._code.code import ReprEntryNative
+        reprec = testdir.inline_runsource("""
+                            def test_repr_entry_native():
+                                x = 0
+                                assert x
+                        """, '--tb=native', '-n1')
+        reports = reprec.getreports("pytest_runtest_logreport")
+        assert len(reports) == 3
+        rep = reports[1]
+        d = serialize_report(rep)
+        a = unserialize_report("testreport", d)
+
+        rep_entries = rep.longrepr.reprtraceback.reprentries
+        a_entries = a.longrepr.reprtraceback.reprentries
+        assert rep_entries == a_entries
+        for i in range(len(a_entries)):
+            assert isinstance(rep_entries[i], ReprEntryNative)
+            assert rep_entries[i].lines == a_entries[i].lines
 
     def test_itemreport_outcomes(self, testdir):
         reprec = testdir.inline_runsource("""

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -118,7 +118,7 @@ class TestReportSerialization:
                             def test_repr_entry():
                                 x = 0
                                 assert x
-                        """, '--showlocals', '-n1')
+                        """, '--showlocals')
         reports = reprec.getreports("pytest_runtest_logreport")
         assert len(reports) == 3
         rep = reports[1]
@@ -143,7 +143,7 @@ class TestReportSerialization:
                             def test_repr_entry_native():
                                 x = 0
                                 assert x
-                        """, '--tb=native', '-n1')
+                        """, '--tb=native')
         reports = reprec.getreports("pytest_runtest_logreport")
         assert len(reports) == 3
         rep = reports[1]

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -104,11 +104,14 @@ def serialize_report(rep):
 
         new_entries = []
         for entry in reprtraceback['reprentries']:
-            new_entry = entry.__dict__
-            for key, value in new_entry.items():
+            entry_data = {
+                'type': type(entry).__name__,
+                'data': entry.__dict__,
+            }
+            for key, value in entry_data['data'].items():
                 if hasattr(value, '__dict__'):
-                    new_entry[key] = value.__dict__
-            new_entries.append(new_entry)
+                    entry_data['data'][key] = value.__dict__
+            new_entries.append(entry_data)
 
         reprtraceback['reprentries'] = new_entries
 


### PR DESCRIPTION
The problem was because we were not handling `ReprEntryNative` objects, which are generated by ``--tb=native`` command-line flag.

@zzzeek I tested this by cloning the branch `reproduce_pytest_196` from `alembic` repository like you instructed and applying this patch:

```diff
diff --git a/tox.ini b/tox.ini
index c8a3c3e..8e1b1cd 100644
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ SQLA_REPO = {env:SQLA_REPO:git+http://git.sqlalchemy.org/sqlalchemy.git}
 cov_args=--cov=alembic --cov-report term --cov-report xml

 deps=pytest==3.2.0
-     pytest-xdist==1.18.2
+     git+https://github.com/nicoddemus/pytest-xdist.git@traceback-error
      mock
      sqla079: {[tox]SQLA_REPO}@rel_0_7_9
      sqla084: {[tox]SQLA_REPO}@rel_0_8_4
```

Could you please test this in your end as well to double check?

Fix #196

