### PR TITLE
Fix crash when transferring internal pytest warnings from workers to the master node

### DIFF
--- a/changelog/214.bugfix
+++ b/changelog/214.bugfix
@@ -1,0 +1,1 @@
+Fix crash when transferring internal pytest warnings from workers to the master node.

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -99,7 +99,7 @@ class SlaveInteractor:
 
     def pytest_logwarning(self, message, code, nodeid, fslocation):
         self.sendevent("logwarning", message=message, code=code, nodeid=nodeid,
-                       fslocation=fslocation)
+                       fslocation=str(fslocation))
 
 
 def serialize_report(rep):


### PR DESCRIPTION
*sigh*

Fix #214
