### PR TITLE
Appveyor and pytest dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 sudo: false
 language: python
 python:
-- '2.6'
-- '2.7'
-- '3.4'
-- '3.5'
-- '3.6'
+  - '2.6'
+  - '2.7'
+  - '3.4'
+  - '3.5'
+  - '3.6'
 env:
-- TOXENV=py-pytest30
-- TOXENV=py-pytest31
-- TOXENV=py-pytest32
+  - TOXENV=py-pytest30
+  - TOXENV=py-pytest31
+  - TOXENV=py-pytest32
+  - TOXENV=py-pytestmaster
+  - TOXENV=py-pytestfeatures
 install: pip install tox setuptools_scm
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,19 +2,37 @@ environment:
   matrix:
   # note: please use "tox --listenvs" to populate the build matrix
   - TOXENV: "py26-pytest30"
+  - TOXENV: "py26-pytest31"
+  - TOXENV: "py26-pytest32"
   - TOXENV: "py27-pytest30"
+  - TOXENV: "py27-pytest31"
+  - TOXENV: "py27-pytest32"
   - TOXENV: "py34-pytest30"
+  - TOXENV: "py34-pytest31"
+  - TOXENV: "py34-pytest32"
   - TOXENV: "py35-pytest30"
+  - TOXENV: "py35-pytest31"
+  - TOXENV: "py35-pytest32"
   - TOXENV: "py36-pytest30"
+  - TOXENV: "py36-pytest31"
+  - TOXENV: "py36-pytest32"
   - TOXENV: "py27-pytest30-pexpect"
-  - TOXENV: "py35-pytest30-pexpect"
+  - TOXENV: "py27-pytest31-pexpect"
+  - TOXENV: "py27-pytest32-pexpect"
+  - TOXENV: "py36-pytest30-pexpect"
+  - TOXENV: "py36-pytest31-pexpect"
+  - TOXENV: "py36-pytest32-pexpect"
+  - TOXENV: "py27-pytestmaster"
+  - TOXENV: "py27-pytestfeatures"
+  - TOXENV: "py36-pytestmaster"
+  - TOXENV: "py36-pytestfeatures"
   - TOXENV: "flakes"
   - TOXENV: "readme"
 
 install:
-  - C:\Python35\python -m pip install tox setuptools_scm
+  - C:\Python36\python -m pip install tox setuptools_scm
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - C:\Python35\python -m tox
+  - C:\Python36\python -m tox

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist=
   py{26,27,34,35,36}-pytest{30,31,32}
   py{27,36}-pytest{30,31,32}-pexpect
+  py{27,36}-pytest{master,features}
   flakes
   readme
 
@@ -17,6 +18,8 @@ deps =
   pytest30: pytest~=3.0.5
   pytest31: pytest~=3.1.0
   pytest32: pytest~=3.2.0
+  pytestmaster: git+https://github.com/pytest-dev/pytest.git@master
+  pytestfeatures: git+https://github.com/pytest-dev/pytest.git@features
   pexpect: pexpect
 platform=
   pexpect: linux|darwin


### PR DESCRIPTION
* Update AppVeyor build matrix
* Test also using `pytest` from `master` and `features` branches;

~~Change the build matrix to:~~

~~* Standard tests: test with all supported python versions using latest pytest~~
~~* pexpect tests using py27 and py36 and latest pytest ~~
~~* Older pytest versions using py27 and py36~~

EDIT: aborted the second part of the PR when I noticed it will be hard to make it work on Travis.