### PR TITLE
Identify correct test crashed during teardown and support multiple test logs from plugins

### DIFF
--- a/changelog/124.bugfix
+++ b/changelog/124.bugfix
@@ -1,0 +1,1 @@
+Fix issue where tests were being incorrectly identified if a worker crashed during the ``teardown`` stage of the test.

--- a/changelog/206.feature
+++ b/changelog/206.feature
@@ -1,0 +1,2 @@
+``xdist`` now supports tests to log results multiple times, improving integration with plugins which require
+it like `pytest-rerunfailures <https://github.com/gocept/pytest-rerunfailures>_`.

--- a/xdist/dsession.py
+++ b/xdist/dsession.py
@@ -230,17 +230,18 @@ class DSession:
             nodeid=nodeid, location=location)
 
     def slave_testreport(self, node, rep):
-        """Emitted when a node calls the pytest_runtest_logreport hook.
-
-        If the node indicates it is finished with a test item, remove
-        the item from the pending list in the scheduler.
-        """
-        if rep.when == "call" or (rep.when == "setup" and not rep.passed):
-            self.sched.mark_test_complete(node, rep.item_index, rep.duration)
-        # self.report_line("testreport %s: %s" %(rep.id, rep.status))
+        """Emitted when a node calls the pytest_runtest_logreport hook."""
         rep.node = node
         self.config.hook.pytest_runtest_logreport(report=rep)
         self._handlefailures(rep)
+
+    def slave_runtest_protocol_complete(self, node, item_index, duration):
+        """
+        Emitted when a node fires the 'runtest_protocol_complete' event,
+        signalling that a test has completed the runtestprotocol and should be
+        removed from the pending list in the scheduler.
+        """
+        self.sched.mark_test_complete(node, item_index, duration)
 
     def slave_collectreport(self, node, rep):
         """Emitted when a node calls the pytest_collectreport hook."""

--- a/xdist/slavemanage.py
+++ b/xdist/slavemanage.py
@@ -315,6 +315,8 @@ class SlaveController(object):
                 self.notify_inproc(eventname, node=self, rep=rep)
             elif eventname == "collectionfinish":
                 self.notify_inproc(eventname, node=self, ids=kwargs['ids'])
+            elif eventname == "runtest_protocol_complete":
+                self.notify_inproc(eventname, node=self, **kwargs)
             elif eventname == "logwarning":
                 self.notify_inproc(eventname, message=kwargs['message'],
                                    code=kwargs['code'], nodeid=kwargs['nodeid'],


### PR DESCRIPTION
While trying to fix #124, I realized the root of the problem was that xdist was trying to identify when a test was "done" on a worker by looking at the report from the `pytest_runtest_logreport`, but this is a problem because it is not entirely obvious when a test is actually "done". `pytest_runtest_logreport` is called for all testing stages, `setup`, `call` and `teardown`, and those stages are called or not depending on specific outcomes:

* a failed `setup` prevent's `call` and `teardown` stages;
* a failed `call` will follow with a `teardown` stage;

And plugins might even affect that by implementing `pytest_runtest_protocol` themselves.

So I figured the problem was trying to implicitly figure out if a test was done based on that information.

To solve this I created an explicit event "runtest_protocol_complete" which is sent by workers after `runtestprotocol`, this way we ensure that a worker is indeed "done" with an item.

---

I also realized that this fixes #206 because we no longer use `pytest_runtest_logreport` to determine if a test is done, allowing plugins to issue multiple `pytest_runtest_logreport` hooks if needed.

I modified `pytest-rerunfailures` locally to skip its check if `xdist` is running, allowing it to log multiple times and it works well:

```
============================= test session starts =============================
platform win32 -- Python 3.5.2, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: C:\Users\bruno\pytest-xdist, inifile: tox.ini
plugins: xdist-1.19.1.dev6+gf8e138b, rerunfailures-2.2, forked-0.2, hypothesis-3.16.0
gw0 [1] / gw1 [1]
scheduling tests via LoadScheduling
RRRRRF
=========================== rerun test summary info ===========================
RERUN .tmp/test_reruns.py::test_example
RERUN .tmp/test_reruns.py::test_example
RERUN .tmp/test_reruns.py::test_example
RERUN .tmp/test_reruns.py::test_example
RERUN .tmp/test_reruns.py::test_example
=========================== short test summary info ===========================
FAIL .tmp/test_reruns.py::test_example
================================== FAILURES ===================================
________________________________ test_example _________________________________
[gw0] win32 -- Python 3.5.2 c:\users\bruno\pytest-xdist\.env35\scripts\python.exe

    def test_example():
>       assert False
E       assert False

.tmp\test_reruns.py:3: AssertionError
====================== 1 failed, 5 rerun in 1.04 seconds ======================
```

I also executed `pytest`'s test suite using this branch and it worked with no problems.

cc @davehunt 