### PR TITLE
Improve UsageError when used with --pdb

### DIFF
--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -105,7 +105,7 @@ def pytest_cmdline_main(config):
         if val("dist") != "no":
             if usepdb:
                 raise pytest.UsageError(
-                    "--pdb incompatible with distributing tests.")
+                    "--pdb is incompatible with distributing tests; try using -n0.")  # noqa: E501
 
 # -------------------------------------------------------------------------
 # fixtures


### PR DESCRIPTION
It might not be clear that pytest-xdist is used at all, and this should
help users to make --pdb work.