### PR TITLE
Stop looping if all workers have died

### DIFF
--- a/changelog/45.bugfix
+++ b/changelog/45.bugfix
@@ -1,0 +1,1 @@
+Fix hang when all worker nodes crash and restart limit is reached

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -701,6 +701,17 @@ class TestNodeFailure:
             "*2 failed*2 passed*",
         ])
 
+    def test_max_slave_restart_die(self, testdir):
+        f = testdir.makepyfile("""
+            import os
+            os._exit(1)
+        """)
+        res = testdir.runpytest(f, '-n4', '--max-slave-restart=0')
+        res.stdout.fnmatch_lines([
+            "*Unexpectedly no active workers*",
+            "*INTERNALERROR*"
+        ])
+
     def test_disable_restart(self, testdir):
         f = testdir.makepyfile("""
             import os

--- a/xdist/dsession.py
+++ b/xdist/dsession.py
@@ -120,6 +120,10 @@ class DSession:
     def loop_once(self):
         """Process one callback from one of the slaves."""
         while 1:
+            if not self._active_nodes:
+                # If everything has died stop looping
+                self.triggershutdown()
+                raise RuntimeError("Unexpectedly no active workers available")
             try:
                 eventcall = self.queue.get(timeout=2.0)
                 break


### PR DESCRIPTION
If the workers are crashing and the restart limit has been met, we need to stop listening for events and trigger an internal error. This is related to #45 

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```


