### PR TITLE
Issue #241 Make copy during serialization of reprtraceback and reprcr…

### DIFF
--- a/changelog/241.bugfix
+++ b/changelog/241.bugfix
@@ -1,0 +1,1 @@
+Fix accidental mutation of test report during serialization causing longrepr string-ification to break.

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -111,18 +111,18 @@ class SlaveInteractor:
 
 def serialize_report(rep):
     def disassembled_report(rep):
-        reprtraceback = rep.longrepr.reprtraceback.__dict__
-        reprcrash = rep.longrepr.reprcrash.__dict__
+        reprtraceback = rep.longrepr.reprtraceback.__dict__.copy()
+        reprcrash = rep.longrepr.reprcrash.__dict__.copy()
 
         new_entries = []
         for entry in reprtraceback['reprentries']:
             entry_data = {
                 'type': type(entry).__name__,
-                'data': entry.__dict__,
+                'data': entry.__dict__.copy(),
             }
             for key, value in entry_data['data'].items():
                 if hasattr(value, '__dict__'):
-                    entry_data['data'][key] = value.__dict__
+                    entry_data['data'][key] = value.__dict__.copy()
             new_entries.append(entry_data)
 
         reprtraceback['reprentries'] = new_entries


### PR DESCRIPTION
This resolves the issue 241 which reported that `report.longrepr` stringification was broken when you enable xdist -nX. The issue had to do with the inadvertent mutation of the individual reprtrackback.reprentries. 