### PR TITLE
 Drop support for EOL Python 2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ pytestdebug.log
 .tox/
 .cache/
 .eggs/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ notifications:
   - pytest-commit@python.org
 
 python:
-- '2.6'
 - '2.7'
 - '3.4'
 - '3.5'

--- a/README.rst
+++ b/README.rst
@@ -229,7 +229,7 @@ You can also add default environments like this:
 .. code-block:: ini
 
     [pytest]
-    addopts = --tx ssh=myhost//python=python2.5 --tx ssh=myhost//python=python2.6
+    addopts = --tx ssh=myhost//python=python2.5 --tx ssh=myhost//python=python3.6
 
 and then just type::
 

--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,23 @@
 
 
 .. image:: http://img.shields.io/pypi/v/pytest-xdist.svg
+    :alt: PyPI version
+    :target: https://pypi.python.org/pypi/pytest-xdist
+
+.. image:: https://img.shields.io/pypi/pyversions/pytest-xdist.svg
+    :alt: Python versions
     :target: https://pypi.python.org/pypi/pytest-xdist
 
 .. image:: https://anaconda.org/conda-forge/pytest-xdist/badges/version.svg
+    :alt: Anaconda version
     :target: https://anaconda.org/conda-forge/pytest-xdist
 
 .. image:: https://travis-ci.org/pytest-dev/pytest-xdist.svg?branch=master
+    :alt: Travis CI build status
     :target: https://travis-ci.org/pytest-dev/pytest-xdist
 
 .. image:: https://ci.appveyor.com/api/projects/status/56eq1a1avd4sdd7e/branch/master?svg=true
+    :alt: AppVeyor build status
     :target: https://ci.appveyor.com/project/pytestbot/pytest-xdist
 
 xdist: pytest distributed testing plugin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
   # note: please use "tox --listenvs" to populate the build matrix
-  - TOXENV: "py26-pytest30"
   - TOXENV: "py27-pytest30"
   - TOXENV: "py34-pytest30"
   - TOXENV: "py35-pytest30"

--- a/changelog/259.removal
+++ b/changelog/259.removal
@@ -1,0 +1,1 @@
+Drop support for EOL Python 2.6.

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,6 @@
-from sys import version_info
-
 from setuptools import setup, find_packages
 
 install_requires = ['execnet>=1.1', 'pytest>=3.0.0', 'pytest-forked']
-
-if version_info < (2, 7):
-    install_requires.append('ordereddict')
 
 
 setup(
@@ -27,6 +22,7 @@ setup(
         ],
     },
     zip_safe=False,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=install_requires,
     setup_requires=['setuptools_scm'],
     classifiers=[
@@ -41,6 +37,11 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Utilities',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -755,9 +755,9 @@ def test_worker_id_fixture(testdir, n):
         with open(fname) as f:
             worker_ids.add(f.read().strip())
     if n == 0:
-        assert worker_ids == set(['master'])
+        assert worker_ids == {'master'}
     else:
-        assert worker_ids == set(['gw0', 'gw1'])
+        assert worker_ids == {'gw0', 'gw1'}
 
 
 @pytest.mark.parametrize('tb',

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -34,7 +34,7 @@ def pytest_addoption(parser):
     parser.addoption('--gx',
                      action="append",
                      dest="gspecs",
-                     help=("add a global test environment, XSpec-syntax. "))
+                     help="add a global test environment, XSpec-syntax. ")
 
 
 @pytest.fixture

--- a/testing/test_dsession.py
+++ b/testing/test_dsession.py
@@ -126,7 +126,7 @@ class TestLoadScheduling:
         sched.add_node(MockNode())
         sched.add_node(MockNode())
         node1, node2 = sched.nodes
-        col = ["xyz"] * (6)
+        col = ["xyz"] * 6
         sched.add_node_collection(node1, col)
         sched.add_node_collection(node2, col)
         sched.schedule()

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # if you change the envlist, please update .travis.yml file as well
 envlist=
-  py{26,27,34,35,36}-pytest{30,31,32}
+  py{27,34,35,36}-pytest{30,31,32}
   py{27,36}-pytest{30,31,32}-pexpect
   py{27,36}-pytest{master,features}
   flakes

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -178,10 +178,6 @@ def remote_initconfig(option_dict, args):
 
 if __name__ == '__channelexec__':
     channel = channel  # noqa
-    # python3.2 is not concurrent import safe, so let's play it safe
-    # https://bitbucket.org/hpk42/pytest/issue/347/pytest-xdist-and-python-32
-    if sys.version_info[:2] == (3, 2):
-        os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
     slaveinput, args, option_dict = channel.receive()
     importpath = os.getcwd()
     sys.path.insert(0, importpath)  # XXX only for remote situations

--- a/xdist/scheduler/loadscope.py
+++ b/xdist/scheduler/loadscope.py
@@ -1,14 +1,9 @@
-try:
-    from collections import OrderedDict
-except ImportError:
-    # Support for Python 2.6
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 
-from py.log import Producer
 from _pytest.runner import CollectReport
-
-from xdist.slavemanage import parse_spec_config
+from py.log import Producer
 from xdist.report import report_collection_diff
+from xdist.slavemanage import parse_spec_config
 
 
 class LoadScopeScheduling:


### PR DESCRIPTION
Pytest and Py have both dropped Python 2.6 as it's been EOL for 4 years.

Also remove some redundant Python 3.2 code (also EOL and looks like it's already dropped), some minor code cleanup, and add a Python version badge.

---

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```


