### PR TITLE
Add support for the new pytest_runtest_logfinish hook (pytest 3.4)

### DIFF
--- a/changelog/266.feature
+++ b/changelog/266.feature
@@ -1,0 +1,1 @@
+Add support for the ``pytest_runtest_logfinish`` hook which will be released in pytest 3.4.

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -375,6 +375,25 @@ class TestTerminalReporting:
             "*1 passed, 1 warnings*",
         ])
 
+    def test_logfinish_hook(self, testdir):
+        """Ensure the pytest_runtest_logfinish hook is being properly handled"""
+        from _pytest import hookspec
+        if not hasattr(hookspec, 'pytest_runtest_logfinish'):
+            pytest.skip('test requires pytest_runtest_logfinish hook in pytest (3.4+)')
+
+        testdir.makeconftest("""
+            def pytest_runtest_logfinish():
+                print('pytest_runtest_logfinish hook called')
+        """)
+        testdir.makepyfile("""
+            def test_func():
+                pass
+        """)
+        result = testdir.runpytest("-n1", "-s")
+        result.stdout.fnmatch_lines([
+            "*pytest_runtest_logfinish hook called*",
+        ])
+
 
 def test_teardownfails_one_function(testdir):
     p = testdir.makepyfile("""

--- a/xdist/dsession.py
+++ b/xdist/dsession.py
@@ -235,6 +235,11 @@ class DSession:
         self.config.hook.pytest_runtest_logstart(
             nodeid=nodeid, location=location)
 
+    def slave_logfinish(self, node, nodeid, location):
+        """Emitted when a node calls the pytest_runtest_logfinish hook."""
+        self.config.hook.pytest_runtest_logfinish(
+            nodeid=nodeid, location=location)
+
     def slave_testreport(self, node, rep):
         """Emitted when a node calls the pytest_runtest_logreport hook."""
         rep.node = node

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -9,6 +9,8 @@
 import sys
 import os
 import time
+
+import _pytest.hookspec
 import pytest
 
 
@@ -92,6 +94,11 @@ class SlaveInteractor:
 
     def pytest_runtest_logstart(self, nodeid, location):
         self.sendevent("logstart", nodeid=nodeid, location=location)
+
+    # the pytest_runtest_logfinish hook was introduced in pytest 3.4
+    if hasattr(_pytest.hookspec, 'pytest_runtest_logfinish'):
+        def pytest_runtest_logfinish(self, nodeid, location):
+            self.sendevent("logfinish", nodeid=nodeid, location=location)
 
     def pytest_runtest_logreport(self, report):
         data = serialize_report(report)

--- a/xdist/slavemanage.py
+++ b/xdist/slavemanage.py
@@ -304,7 +304,7 @@ class SlaveController(object):
                 self._down = True
                 self.slaveoutput = kwargs['slaveoutput']
                 self.notify_inproc("slavefinished", node=self)
-            elif eventname == "logstart":
+            elif eventname in ("logstart", "logfinish"):
                 self.notify_inproc(eventname, node=self, **kwargs)
             elif eventname in (
                     "testreport", "collectreport", "teardownreport"):


### PR DESCRIPTION
Handle the new `pytest_runtest_logfinish` hook introduced in pytest-dev/pytest#3102, which will be released in pytest 3.4.