### PR TITLE
Add backward compatibility for ``slaveoutput`` attribute to ``WorkerController`` instances

### DIFF
--- a/changelog/285.bugfix
+++ b/changelog/285.bugfix
@@ -1,0 +1,1 @@
+Add backward compatibility for ``slaveoutput`` attribute to ``WorkerController`` instances.

--- a/xdist/workermanage.py
+++ b/xdist/workermanage.py
@@ -307,7 +307,7 @@ class WorkerController(object):
                 self.notify_inproc(eventname, node=self, **kwargs)
             elif eventname == "workerfinished":
                 self._down = True
-                self.workeroutput = kwargs['workeroutput']
+                self.workeroutput = self.slaveoutput = kwargs['workeroutput']
                 self.notify_inproc("workerfinished", node=self)
             elif eventname in ("logstart", "logfinish"):
                 self.notify_inproc(eventname, node=self, **kwargs)


### PR DESCRIPTION
Fix #285
Fix pytest-dev/pytest-cov#191
