### PR TITLE
plugin: get cpu_count from sched_getaffinity

### DIFF
--- a/changelog/9.bugfix
+++ b/changelog/9.bugfix
@@ -1,0 +1,1 @@
+Fix issue of virtualized or containerized environments not reporting the number of CPUs correctly

--- a/changelog/9.bugfix
+++ b/changelog/9.bugfix
@@ -1,1 +1,1 @@
-Fix issue of virtualized or containerized environments not reporting the number of CPUs correctly
+Fix issue of virtualized or containerized environments not reporting the number of CPUs correctly.

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -31,7 +31,9 @@ def test_dist_options(testdir):
 
 def test_auto_detect_cpus(testdir, monkeypatch):
     import os
-    if hasattr(os, 'cpu_count'):
+    if hasattr(os, 'sched_getaffinity'):
+        monkeypatch.setattr(os, 'sched_getaffinity', lambda _pid: set(range(99)))
+    elif hasattr(os, 'cpu_count'):
         monkeypatch.setattr(os, 'cpu_count', lambda: 99)
     else:
         import multiprocessing

--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -6,13 +6,14 @@ def parse_numprocesses(s):
     if s == 'auto':
         try:
             from os import sched_getaffinity
-            def cpu_count():
-                return len(sched_getaffinity(0))
         except ImportError:
             try:
                 from os import cpu_count
             except ImportError:
                 from multiprocessing import cpu_count
+        else:
+            def cpu_count():
+                return len(sched_getaffinity(0))
 
         try:
             n = cpu_count()

--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -5,9 +5,15 @@ import pytest
 def parse_numprocesses(s):
     if s == 'auto':
         try:
-            from os import cpu_count
+            from os import sched_getaffinity
+            def cpu_count():
+                return len(sched_getaffinity(0))
         except ImportError:
-            from multiprocessing import cpu_count
+            try:
+                from os import cpu_count
+            except ImportError:
+                from multiprocessing import cpu_count
+
         try:
             n = cpu_count()
         except NotImplementedError:


### PR DESCRIPTION
An attempt to fix the #9 issue as it causes trouble in Travis. 

As state by the [doc](https://docs.python.org/3/library/os.html#os.cpu_count), `cpu_count`
 doesn't return the number of usable CPUs.