### PR TITLE
Release 1.22.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,18 @@
+pytest-xdist 1.22.3 (2018-07-23)
+================================
+
+Bug Fixes
+---------
+
+- Fix issue of virtualized or containerized environments not reporting the number of CPUs correctly. (`#9 <https://github.com/pytest-dev/pytest-xdist/issues/9>`_)
+
+
+Trivial Changes
+---------------
+
+- Make all classes subclass from ``object`` and fix ``super()`` call in ``LoadFileScheduling``; (`#297 <https://github.com/pytest-dev/pytest-xdist/issues/297>`_)
+
+
 pytest-xdist 1.22.2 (2018-02-26)
 ================================
 

--- a/HOWTORELEASE.rst
+++ b/HOWTORELEASE.rst
@@ -24,13 +24,13 @@ To publish a new release ``X.Y.Z``, the steps are as follows:
 
 #. Create a new branch named ``release-X.Y.Z`` from the latest ``master``.
 
-#. Install ``pytest-xdist`` and dev requirements in a virtualenv::
+#. Install ``tox`` in a virtualenv::
 
-    $ pip install -e . -U -r dev-requirements.txt
+    $ pip install tox
 
-#. Update ``CHANGELOG.rst`` file by running::
+#. Update the necessary files with::
 
-    $ towncrier --version X.Y.Z --yes
+    $ tox -e release -- X.Y.Z
 
 #. Commit and push the branch for review.
 

--- a/changelog/297.trivial.rst
+++ b/changelog/297.trivial.rst
@@ -1,1 +1,0 @@
-Make all classes subclass from ``object`` and fix ``super()`` call in ``LoadFileScheduling``;

--- a/changelog/9.bugfix
+++ b/changelog/9.bugfix
@@ -1,1 +1,0 @@
-Fix issue of virtualized or containerized environments not reporting the number of CPUs correctly.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,0 @@
-towncrier

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,18 @@ deps = readme
 skip_install = true
 commands = python setup.py check -r -s
 
+[testenv:release]
+changedir=
+decription = do a release, required posarg of the version number
+basepython = python3.6
+skipsdist = True
+usedevelop = True
+passenv = *
+deps =
+    towncrier
+commands =
+    towncrier --version {posargs} --yes
 
 [pytest]
 addopts = -rsfxX
-;; hello
+


### PR DESCRIPTION
@RonnyPfannschmidt, on this same PR I have changed the release process to use `tox` like we did with the other projects. The process is well known by now so I think it would be OK to do both on the same PR (although in different commits of course), but let me know if you prefer to do this in two PRs instead.