### PR TITLE
Revert dropped support to old pytest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
 - TOXENV=py-pytest31
 - TOXENV=py-pytest32
 - TOXENV=py-pytest33
+- TOXENV=py-pytest36
 
 install: pip install tox setuptools_scm
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ python:
 - '3.5'
 - '3.6'
 env:
-- TOXENV=py-pytest34
-- TOXENV=py-pytest35
-- TOXENV=py-pytest36
+- TOXENV=py-pytest30
+- TOXENV=py-pytest31
+- TOXENV=py-pytest32
+- TOXENV=py-pytest33
 
 install: pip install tox setuptools_scm
 script: tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,16 @@
+pytest-xdist 1.22.5 (2018-07-27)
+================================
+
+Bug Fixes
+---------
+
+- `#321 <https://github.com/pytest-dev/pytest-xdist/issues/321>`_: Revert change that dropped support for ``pytest<3.4``.
+
+  This change caused problems in some installations, and was a mistaken
+  in the first place as we should not change version requirements
+  in bug-fix releases unless they fix an actual bug.
+
+
 pytest-xdist 1.22.4 (2018-07-27)
 ================================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ pytest-xdist 1.22.5 (2018-07-27)
 Bug Fixes
 ---------
 
-- `#321 <https://github.com/pytest-dev/pytest-xdist/issues/321>`_: Revert change that dropped support for ``pytest<3.4``.
+- `#321 <https://github.com/pytest-dev/pytest-xdist/issues/321>`_: Revert change that dropped support for ``pytest<3.4`` and require ``six``.
 
   This change caused problems in some installations, and was a mistaken
   in the first place as we should not change version requirements

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,22 @@
 environment:
   matrix:
-  - TOXENV: "py27-pytest36"
-  - TOXENV: "py34-pytest36"
-  - TOXENV: "py35-pytest36"
-  - TOXENV: "py36-pytest36"
-  - TOXENV: "py27-pytest36-pexpect"
-  - TOXENV: "py36-pytest36-pexpect"
+  # note: please use "tox --listenvs" to populate the build matrix
+  - TOXENV: "py27-pytest33"
+  - TOXENV: "py34-pytest33"
+  - TOXENV: "py35-pytest33"
+  - TOXENV: "py36-pytest33"
+  - TOXENV: "py27-pytest33-pexpect"
+  - TOXENV: "py36-pytest33-pexpect"
   - TOXENV: "flakes"
   - TOXENV: "readme"
 
 install:
-  - C:\Python36\python -m pip install -U tox setuptools_scm pip
+  - C:\Python35\python -m pip install -U tox setuptools_scm pip
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - C:\Python36\python -m tox
+  - C:\Python35\python -m tox
 
 # We don't deploy anything on tags with AppVeyor, we use Travis instead, so we
 # might as well save resources

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,18 +5,19 @@ environment:
   - TOXENV: "py34-pytest33"
   - TOXENV: "py35-pytest33"
   - TOXENV: "py36-pytest33"
+  - TOXENV: "py36-pytest36"
   - TOXENV: "py27-pytest33-pexpect"
   - TOXENV: "py36-pytest33-pexpect"
   - TOXENV: "flakes"
   - TOXENV: "readme"
 
 install:
-  - C:\Python35\python -m pip install -U tox setuptools_scm pip
+  - C:\Python36\python -m pip install -U tox setuptools_scm pip
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - C:\Python35\python -m tox
+  - C:\Python36\python -m tox
 
 # We don't deploy anything on tags with AppVeyor, we use Travis instead, so we
 # might as well save resources

--- a/changelog/321.bugfix.rst
+++ b/changelog/321.bugfix.rst
@@ -1,0 +1,5 @@
+Revert change that dropped support for ``pytest<3.4``.
+
+This change caused problems in some installations, and was a mistaken
+in the first place as we should not change version requirements
+in bug-fix releases unless they fix an actual bug.

--- a/changelog/321.bugfix.rst
+++ b/changelog/321.bugfix.rst
@@ -1,5 +1,0 @@
-Revert change that dropped support for ``pytest<3.4``.
-
-This change caused problems in some installations, and was a mistaken
-in the first place as we should not change version requirements
-in bug-fix releases unless they fix an actual bug.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-install_requires = ['execnet>=1.1', 'pytest>=3.0.0', 'pytest-forked']
+install_requires = ['execnet>=1.1', 'pytest>=3.0.0', 'pytest-forked', "six"]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-install_requires = ['execnet>=1.1', 'pytest>=3.4', 'pytest-forked']
+install_requires = ['execnet>=1.1', 'pytest>=3.0.0', 'pytest-forked']
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 # if you change the envlist, please update .travis.yml file as well
 envlist=
-  py{27,34,35,36}-pytest{30,31,32,33}
-  py{27,36}-pytest{30,31,32,33}-pexpect
+  py{27,34,35,36}-pytest{30,31,32,33,36}
+  py{27,36}-pytest{30,36}-pexpect
   py{27,36}-pytest{master,features}
   flakes
   readme
@@ -19,6 +19,7 @@ deps =
   pytest31: pytest~=3.1.0
   pytest32: pytest~=3.2.0
   pytest33: pytest~=3.3.0
+  pytest36: pytest~=3.6.0
   pytestmaster: git+https://github.com/pytest-dev/pytest.git@master
   pytestfeatures: git+https://github.com/pytest-dev/pytest.git@features
   pexpect: pexpect

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 # if you change the envlist, please update .travis.yml file as well
 envlist=
-  py{27,34,35,36}-pytest{34,35,36}
-  py{27,36}-pytest36-pexpect
+  py{27,34,35,36}-pytest{30,31,32,33}
+  py{27,36}-pytest{30,31,32,33}-pexpect
   py{27,36}-pytest{master,features}
   flakes
   readme
@@ -15,9 +15,10 @@ deps =
   pycmd
   # to avoid .eggs
   setuptools_scm
-  pytest34: pytest~=3.4.0
-  pytest35: pytest~=3.5.0
-  pytest36: pytest~=3.6.0
+  pytest30: pytest~=3.0.5
+  pytest31: pytest~=3.1.0
+  pytest32: pytest~=3.2.0
+  pytest33: pytest~=3.3.0
   pytestmaster: git+https://github.com/pytest-dev/pytest.git@master
   pytestfeatures: git+https://github.com/pytest-dev/pytest.git@features
   pexpect: pexpect


### PR DESCRIPTION
This release reverts the change that dropped support for older pytest versions. We should consider this change only for `1.23`.

Issues:

https://github.com/pytest-dev/pytest/issues/3724
https://github.com/pytest-dev/pytest-xdist/issues/319
