### PR TITLE
Optimize collection performance

### DIFF
--- a/changelog/330.feature.rst
+++ b/changelog/330.feature.rst
@@ -1,0 +1,1 @@
+Improve collection performance by reducing the number of events sent to ``master`` node.

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -321,8 +321,6 @@ class TestWorkerInteractor:
         assert not ev.kwargs
         ev = worker.popevent()
         assert ev.name == "collectreport"
-        ev = worker.popevent()
-        assert ev.name == "collectreport"
         rep = unserialize_report(ev.name, ev.kwargs["data"])
         assert rep.failed
         ev = worker.popevent("collectionfinish")

--- a/xdist/dsession.py
+++ b/xdist/dsession.py
@@ -257,9 +257,13 @@ class DSession(object):
         self.sched.mark_test_complete(node, item_index, duration)
 
     def worker_collectreport(self, node, rep):
-        """Emitted when a node calls the pytest_collectreport hook."""
-        if rep.failed:
-            self._failed_worker_collectreport(node, rep)
+        """Emitted when a node calls the pytest_collectreport hook.
+
+        Because we only need the report when there's a failure, as optimization
+        we only expect to receive failed reports from workers (#330).
+        """
+        assert rep.failed
+        self._failed_worker_collectreport(node, rep)
 
     def worker_logwarning(self, message, code, nodeid, fslocation):
         """Emitted when a node calls the pytest_logwarning hook."""

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -109,8 +109,10 @@ class WorkerInteractor(object):
         self.sendevent("testreport", data=data)
 
     def pytest_collectreport(self, report):
-        data = serialize_report(report)
-        self.sendevent("collectreport", data=data)
+        # master only needs reports that failed, as optimization send only them instead (#330)
+        if report.failed:
+            data = serialize_report(report)
+            self.sendevent("collectreport", data=data)
 
     def pytest_logwarning(self, message, code, nodeid, fslocation):
         self.sendevent(


### PR DESCRIPTION
Do not send the collection report events when the collection was successful
because master only needs the failed ones.

Fix #330
