### PR TITLE
WIP use multiple threads for setting up workers

### DIFF
--- a/changelog/346.feature
+++ b/changelog/346.feature
@@ -1,0 +1,1 @@
+Use threads when setting up workers. This reduces the overhead of setting up workers by around 66% in many cases.

--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -34,6 +34,13 @@ def parse_numprocesses(s):
         return int(s)
 
 
+def parse_numthreads(s):
+    if s == "auto":
+        return auto_detect_cpus()
+    else:
+        return int(s)
+
+
 def pytest_addoption(parser):
     group = parser.getgroup("xdist", "distributed and subprocess testing")
     group._addoption(
@@ -131,6 +138,17 @@ def pytest_addoption(parser):
         type="pathlist",
         help="directories to check for changes",
         default=[py.path.local()],
+    )
+    group._addoption(
+        "--numthreads",
+        dest="numthreads",
+        metavar="numthreads",
+        action="store",
+        type=parse_numthreads,
+        default="auto",
+        help="the number of threads to use when instantiating new workers, "
+        "you can use 'auto' here for auto detection CPUs number on "
+        "host system",
     )
 
 

--- a/xdist/workermanage.py
+++ b/xdist/workermanage.py
@@ -64,13 +64,9 @@ class NodeManager(object):
         self.config.hook.pytest_xdist_setupnodes(config=self.config, specs=self.specs)
         self.trace("setting up nodes")
 
-        numthreads = min([
-            self.config.option.numthreads,
-            len(self.specs)
-        ])
+        numthreads = min([self.config.option.numthreads, len(self.specs)])
         nodes = ThreadPool(numthreads).map(
-            lambda spec: self.setup_node(spec, putevent),
-            [spec for spec in self.specs]
+            lambda spec: self.setup_node(spec, putevent), [spec for spec in self.specs]
         )
 
         return nodes


### PR DESCRIPTION
In my experiments, this pull request reduces the amount of overhead in setting up workers by about 66%. This is particularly helpful in situations where a large number of cpu cores are available. In the case of hundreds or thousands of workers, this is still quite a bit of overhead, however this change is minimal and reducing overhead further will likely involve significant amount of work.