### PR TITLE
Add --maxprocesses option to use with --numprocesses=auto

### DIFF
--- a/changelog/337.feature
+++ b/changelog/337.feature
@@ -1,3 +1,0 @@
-```
-Add --maxprocesses command-line option to limit the maximum number of workers when using --numprocesses=auto
-```

--- a/changelog/337.feature
+++ b/changelog/337.feature
@@ -1,0 +1,3 @@
+```
+Add --maxprocesses command-line option to limit the maximum number of workers when using --numprocesses=auto
+```

--- a/changelog/337.feature.rst
+++ b/changelog/337.feature.rst
@@ -1,0 +1,1 @@
+New ``--maxprocesses`` command-line option that limits the maximum number of workers when using ``--numprocesses=auto``.

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -25,6 +25,10 @@ def test_dist_options(testdir):
     check_options(config)
     assert config.option.dist == "load"
     assert config.option.tx == ["popen"] * 2
+    config = testdir.parseconfigure("--numprocesses", "3", "--maxprocesses", "2")
+    check_options(config)
+    assert config.option.dist == "load"
+    assert config.option.tx == ["popen"] * 2
     config = testdir.parseconfigure("-d")
     check_options(config)
     assert config.option.dist == "load"

--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -47,7 +47,7 @@ def pytest_addoption(parser):
         "you can use 'auto' here for auto detection CPUs number on "
         "host system",
     )
-    group._addoption(
+    group.addoption(
         "--maxprocesses",
         dest="maxprocesses",
         metavar="maxprocesses",

--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -47,6 +47,14 @@ def pytest_addoption(parser):
         "you can use 'auto' here for auto detection CPUs number on "
         "host system",
     )
+    group._addoption(
+        "--maxprocesses",
+        dest="maxprocesses",
+        metavar="maxprocesses",
+        action="store",
+        type=int,
+        help="limit the maximum number of workers to process the tests when using --numprocesses=auto",
+    )
     group.addoption(
         "--max-worker-restart",
         "--max-slave-restart",
@@ -172,7 +180,10 @@ def pytest_cmdline_main(config):
     if config.option.numprocesses:
         if config.option.dist == "no":
             config.option.dist = "load"
-        config.option.tx = ["popen"] * config.option.numprocesses
+        numprocesses = config.option.numprocesses
+        if config.option.maxprocesses:
+            numprocesses = min(numprocesses, config.option.maxprocesses)
+        config.option.tx = ["popen"] * numprocesses
     if config.option.distload:
         config.option.dist = "load"
     val = config.getvalue

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -234,6 +234,7 @@ def remote_initconfig(option_dict, args):
     config.option.dist = "no"
     config.option.distload = False
     config.option.numprocesses = None
+    config.option.maxprocesses = None
     config.args = args
     return config
 


### PR DESCRIPTION
It limits the maximum number of workers when using --numprocesses=auto