### PR TITLE
Fix handling of skipped modules with pytest.skip at module level

### DIFF
--- a/changelog/332.bugfix.rst
+++ b/changelog/332.bugfix.rst
@@ -1,0 +1,1 @@
+Fix report of module-level skips (``pytest.skip(reason, allow_module_level=True)``).

--- a/xdist/dsession.py
+++ b/xdist/dsession.py
@@ -259,10 +259,10 @@ class DSession(object):
     def worker_collectreport(self, node, rep):
         """Emitted when a node calls the pytest_collectreport hook.
 
-        Because we only need the report when there's a failure, as optimization
-        we only expect to receive failed reports from workers (#330).
+        Because we only need the report when there's a failure/skip, as optimization
+        we only expect to receive failed/skipped reports from workers (#330).
         """
-        assert rep.failed
+        assert not rep.passed
         self._failed_worker_collectreport(node, rep)
 
     def worker_logwarning(self, message, code, nodeid, fslocation):

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -110,8 +110,8 @@ class WorkerInteractor(object):
         self.sendevent("testreport", data=data)
 
     def pytest_collectreport(self, report):
-        # master only needs reports that failed, as optimization send only them instead (#330)
-        if report.failed:
+        # send only reports that have not passed to master as optimization (#330)
+        if not report.passed:
             data = serialize_report(report)
             self.sendevent("collectreport", data=data)
 


### PR DESCRIPTION
Fix #332

