### PR TITLE
fix a bug with gevent monkeypatch

### DIFF
--- a/changelog/378.bugfix.rst
+++ b/changelog/378.bugfix.rst
@@ -1,0 +1,1 @@
+Fix support for gevent monkeypatching

--- a/xdist/workermanage.py
+++ b/xdist/workermanage.py
@@ -268,7 +268,7 @@ class WorkerController(object):
         if not self._down:
             try:
                 self.sendcommand("shutdown")
-            except IOError:
+            except (IOError, OSError):
                 pass
             self._shutdown_sent = True
 


### PR DESCRIPTION
When monkeypatching gevent, pipe errors are output as OSError not IOError.

https://github.com/gevent/gevent/issues/186
