### PR TITLE
Check that we can serialize the warning detail attr

### DIFF
--- a/changelog/379.bugfix.rst
+++ b/changelog/379.bugfix.rst
@@ -1,0 +1,2 @@
+Attributes of _WARNING_DETAILS are checked to make sure they can be dumped
+prior to serializing the warning for submission to the master node.

--- a/changelog/379.bugfix.rst
+++ b/changelog/379.bugfix.rst
@@ -1,2 +1,2 @@
-Attributes of _WARNING_DETAILS are checked to make sure they can be dumped
-prior to serializing the warning for submission to the master node.
+Warning attributes are checked to make sure they can be dumped prior to
+serializing the warning for submission to the master node.

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -825,9 +825,8 @@ class TestWarnings:
             # The socket itself will end up attached as a value in
             # _WARNING_DETAIL. We need to test that it is not serialized
             # (it can't be, so the test will fail if we try to).
+            @pytest.mark.filterwarnings('always')  
             def test_func(tmpdir):
-                warnings.resetwarnings()
-                warnings.simplefilter('always', ResourceWarning)
                 abuse_socket()
                 gc.collect()
         """

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -803,6 +803,37 @@ class TestWarnings:
         result = testdir.runpytest(n)
         result.stdout.fnmatch_lines(["*UserWarning*foo.txt*", "*1 passed, 1 warnings*"])
 
+    @pytest.mark.parametrize("n", ["-n0", "-n1"])
+    def test_unserializable_warning_details(self, testdir, n):
+        """Check that warnings with unserializable _WARNING_DETAILS are
+        handled correctly (#379).
+        """
+        testdir.makepyfile(
+            """
+            import warnings, pytest
+            import socket
+            import gc
+            def abuse_socket():
+                s = socket.socket()
+                del s
+
+            # Deliberately provoke a ResourceWarning for an unclosed socket.
+            # The socket itself will end up attached as a value in
+            # _WARNING_DETAIL. We need to test that it is not serialized
+            # (it can't be, so the test will fail if we try to).
+            def test_func(tmpdir):
+                warnings.resetwarnings()
+                warnings.simplefilter('always', ResourceWarning)
+                abuse_socket()
+                gc.collect()
+        """
+        )
+        testdir.syspathinsert()
+        result = testdir.runpytest(n)
+        result.stdout.fnmatch_lines(
+            ["*ResourceWarning*unclosed*", "*1 passed, 1 warnings*"]
+        )
+
 
 class TestNodeFailure:
     def test_load_single(self, testdir):

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 import textwrap
 
 import py
@@ -808,6 +809,9 @@ class TestWarnings:
         """Check that warnings with unserializable _WARNING_DETAILS are
         handled correctly (#379).
         """
+        if sys.version_info[0] < 3:
+            # The issue is only present in Python 3 warnings
+            return
         testdir.makepyfile(
             """
             import warnings, pytest

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -825,7 +825,7 @@ class TestWarnings:
             # The socket itself will end up attached as a value in
             # _WARNING_DETAIL. We need to test that it is not serialized
             # (it can't be, so the test will fail if we try to).
-            @pytest.mark.filterwarnings('always') 
+            @pytest.mark.filterwarnings('always')
             def test_func(tmpdir):
                 abuse_socket()
                 gc.collect()

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -825,7 +825,7 @@ class TestWarnings:
             # The socket itself will end up attached as a value in
             # _WARNING_DETAIL. We need to test that it is not serialized
             # (it can't be, so the test will fail if we try to).
-            @pytest.mark.filterwarnings('always')  
+            @pytest.mark.filterwarnings('always') 
             def test_func(tmpdir):
                 abuse_socket()
                 gc.collect()

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -224,7 +224,7 @@ def serialize_warning_message(warning_message):
         try:
             dumps(attr)
         except DumpError:
-            result[attr_name] = None
+            result[attr_name] = repr(attr)
         else:
             result[attr_name] = attr
     return result

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -218,7 +218,15 @@ def serialize_warning_message(warning_message):
     for attr_name in warning_message._WARNING_DETAILS:
         if attr_name in ("message", "category"):
             continue
-        result[attr_name] = getattr(warning_message, attr_name)
+        attr = getattr(warning_message, attr_name)
+        # Check if we can serialize the warning detail, marking `None` otherwise
+        # Note that we need to define the attr (even as `None`) to allow deserializing
+        try:
+            dumps(attr)
+        except DumpError:
+            result[attr_name] = None
+        else:
+            result[attr_name] = attr
     return result
 
 


### PR DESCRIPTION




Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```

I was running into the same issue addressed in #349, except instead of failing to serialize an arg of the warning, I was unable to serialize a warning detail of the warning. To reproduce the error, you can cause a ResourceWarning due to an unclosed socket. One of the warning details will be the socket that wasn't closed, which can't be serialized.

This PR addresses the issue by performing the same check as #349.