### PR TITLE
Prepare for the removal of pytest_logwarning in pytest 4.1

### DIFF
--- a/changelog/384.bugfix.rst
+++ b/changelog/384.bugfix.rst
@@ -1,1 +1,1 @@
-Add support for pytest 4.1.
+pytest 4.1 support: ``ExceptionInfo`` API changes.

--- a/changelog/390.bugfix.rst
+++ b/changelog/390.bugfix.rst
@@ -1,0 +1,1 @@
+pytest 4.1 support: ``pytest_logwarning`` hook removed.

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -115,14 +115,17 @@ class WorkerInteractor(object):
             data = serialize_report(report)
             self.sendevent("collectreport", data=data)
 
-    def pytest_logwarning(self, message, code, nodeid, fslocation):
-        self.sendevent(
-            "logwarning",
-            message=message,
-            code=code,
-            nodeid=nodeid,
-            fslocation=str(fslocation),
-        )
+    # the pytest_logwarning hook was removed in pytest 4.1
+    if hasattr(_pytest.hookspec, "pytest_logwarning"):
+
+        def pytest_logwarning(self, message, code, nodeid, fslocation):
+            self.sendevent(
+                "logwarning",
+                message=message,
+                code=code,
+                nodeid=nodeid,
+                fslocation=str(fslocation),
+            )
 
     # the pytest_warning_captured hook was introduced in pytest 3.8
     if hasattr(_pytest.hookspec, "pytest_warning_captured"):


### PR DESCRIPTION
Noticed this while working on the removal of the legacy warning system on pytest