### PR TITLE
Fix test_remote_usage_prog which started to break with pytest@features

### DIFF
--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -1,4 +1,3 @@
-import os
 import py
 import pprint
 import pytest
@@ -433,8 +432,6 @@ def test_remote_mainargv(testdir):
 def test_remote_usage_prog(testdir, request):
     if not hasattr(request.config._parser, "prog"):
         pytest.skip("prog not available in config parser")
-    prog = os.path.basename(sys.argv[0])
-
     testdir.makeconftest(
         """
         import pytest
@@ -462,5 +459,5 @@ def test_remote_usage_prog(testdir, request):
     result = testdir.runpytest_subprocess("-n1")
     assert result.ret == 1
     result.stdout.fnmatch_lines(
-        ["usage: %s *" % prog, "%s: error: my_usage_error" % prog]
+        ["usage: pytest.py *", "pytest.py: error: my_usage_error"]
     )


### PR DESCRIPTION
Not sure why this started to fail only on `features` (see https://travis-ci.org/pytest-dev/pytest-xdist/builds/467106087?utm_source=github_status&utm_medium=notification), but this seems to fix it in all versions, although I'm not sure it is correct.