### PR TITLE
Handle pytest_logwarning deprecation better and prepare next release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+pytest-xdist 1.26.1 (2019-01-28)
+================================
+
+Bug Fixes
+---------
+
+- `#406 <https://github.com/pytest-dev/pytest-xdist/issues/406>`_: Do not implement deprecated ``pytest_logwarning`` hook in pytest versions where it is deprecated.
+
+
 pytest-xdist 1.26.0 (2019-01-11)
 ================================
 

--- a/changelog/406.bugfix.rst
+++ b/changelog/406.bugfix.rst
@@ -1,0 +1,1 @@
+Do not implement deprecated ``pytest_logwarning`` hook in pytest versions where it is deprecated.

--- a/changelog/406.bugfix.rst
+++ b/changelog/406.bugfix.rst
@@ -1,1 +1,0 @@
-Do not implement deprecated ``pytest_logwarning`` hook in pytest versions where it is deprecated.

--- a/xdist/remote.py
+++ b/xdist/remote.py
@@ -115,8 +115,10 @@ class WorkerInteractor(object):
             data = serialize_report(report)
             self.sendevent("collectreport", data=data)
 
-    # the pytest_logwarning hook was removed in pytest 4.1
-    if hasattr(_pytest.hookspec, "pytest_logwarning"):
+    # the pytest_logwarning hook was deprecated since pytest 4.0
+    if hasattr(
+        _pytest.hookspec, "pytest_logwarning"
+    ) and not _pytest.hookspec.pytest_logwarning.pytest_spec.get("warn_on_impl"):
 
         def pytest_logwarning(self, message, code, nodeid, fslocation):
             self.sendevent(


### PR DESCRIPTION
cc @Zac-HD 