### PR TITLE
Improve behavior of --numprocesses=auto and --pdb

### DIFF
--- a/changelog/415.feature
+++ b/changelog/415.feature
@@ -1,0 +1,1 @@
+Improve behavior of ``--numprocesses=auto`` to work well with ``--pdb`` option.

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -36,6 +36,7 @@ def test_dist_options(testdir):
 
 def test_auto_detect_cpus(testdir, monkeypatch):
     import os
+    from xdist.plugin import pytest_cmdline_main as check_options
 
     if hasattr(os, "sched_getaffinity"):
         monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(99)))
@@ -51,6 +52,11 @@ def test_auto_detect_cpus(testdir, monkeypatch):
 
     config = testdir.parseconfigure("-nauto")
     assert config.getoption("numprocesses") == 99
+
+    config = testdir.parseconfigure("-nauto", "--pdb")
+    check_options(config)
+    assert config.getoption("usepdb")
+    assert config.getoption("numprocesses") == 0
 
     monkeypatch.delattr(os, "sched_getaffinity", raising=False)
     monkeypatch.setenv("TRAVIS", "true")

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -458,5 +458,5 @@ def test_remote_usage_prog(testdir, request):
     result = testdir.runpytest_subprocess("-n1")
     assert result.ret == 1
     result.stdout.fnmatch_lines(
-        ["usage: pytest.py *", "pytest.py: error: my_usage_error"]
+        ["*usage: pytest.py *", "pytest.py: error: my_usage_error"]
     )

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -458,5 +458,5 @@ def test_remote_usage_prog(testdir, request):
     result = testdir.runpytest_subprocess("-n1")
     assert result.ret == 1
     result.stdout.fnmatch_lines(
-        ["*usage: pytest.py *", "pytest.py: error: my_usage_error"]
+        ["*usage: *", "*error: my_usage_error"]
     )

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -457,6 +457,4 @@ def test_remote_usage_prog(testdir, request):
 
     result = testdir.runpytest_subprocess("-n1")
     assert result.ret == 1
-    result.stdout.fnmatch_lines(
-        ["*usage: *", "*error: my_usage_error"]
-    )
+    result.stdout.fnmatch_lines(["*usage: *", "*error: my_usage_error"])

--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -27,10 +27,14 @@ def auto_detect_cpus():
     return n if n else 1
 
 
+class AutoInt(int):
+    """Mark value as auto-detected."""
+
+
 def parse_numprocesses(s):
     if s == "auto":
-        return auto_detect_cpus()
-    else:
+        return AutoInt(auto_detect_cpus())
+    elif s is not None:
         return int(s)
 
 
@@ -45,7 +49,7 @@ def pytest_addoption(parser):
         type=parse_numprocesses,
         help="shortcut for '--dist=load --tx=NUM*popen', "
         "you can use 'auto' here for auto detection CPUs number on "
-        "host system",
+        "host system and it will be 0 when used with --pdb",
     )
     group.addoption(
         "--maxprocesses",
@@ -177,6 +181,10 @@ def pytest_configure(config):
 
 @pytest.mark.tryfirst
 def pytest_cmdline_main(config):
+    usepdb = config.getoption("usepdb")  # a core option
+    if isinstance(config.option.numprocesses, AutoInt):
+        config.option.numprocesses = 0 if usepdb else int(config.option.numprocesses)
+
     if config.option.numprocesses:
         if config.option.dist == "no":
             config.option.dist = "load"
@@ -188,11 +196,10 @@ def pytest_cmdline_main(config):
         config.option.dist = "load"
     val = config.getvalue
     if not val("collectonly"):
-        usepdb = config.getoption("usepdb")  # a core option
         if val("dist") != "no":
             if usepdb:
                 raise pytest.UsageError(
-                    "--pdb is incompatible with distributing tests; try using -n0."
+                    "--pdb is incompatible with distributing tests; try using -n0 or -nauto."
                 )  # noqa: E501
 
 


### PR DESCRIPTION
I was getting annoyed by changing `pytest -ff -n=auto ...` command when I wanted to append only `--pdb`. With this PR one can use `-n=auto` and anytime simply append `--pdb` without getting the `UsageError`.