### PR TITLE
add auto_cpu check if n exceeds host cpus

### DIFF
--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -64,6 +64,17 @@ def test_auto_detect_cpus(testdir, monkeypatch):
     assert config.getoption("numprocesses") == 2
 
 
+def test_parse_numprocesses(monkeypatch):
+    import xdist.plugin
+    from xdist.plugin import parse_numprocesses
+
+    auto_proc = 2
+    monkeypatch.setattr(xdist.plugin, "auto_detect_cpus", lambda: auto_proc)
+    assert parse_numprocesses("auto") == auto_proc  # requests auto value
+    assert parse_numprocesses("5") == auto_proc  # exceeds auto value
+    assert parse_numprocesses("1") == 1  # under auto value
+
+
 def test_boxed_with_collect_only(testdir):
     from xdist.plugin import pytest_cmdline_main as check_options
 

--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -32,10 +32,13 @@ class AutoInt(int):
 
 
 def parse_numprocesses(s):
+    auto_cpus = AutoInt(auto_detect_cpus())
+
     if s == "auto":
-        return AutoInt(auto_detect_cpus())
+        return auto_cpus
     elif s is not None:
-        return int(s)
+        # prevents failure with cpu selection exceeds host hardware
+        return int(s) if int(s) <= auto_cpus else auto_cpus
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
I was working with this plugin and noticed if the `n` I provided exceeded the number of CPUs I had it would generate an `INTERNAL ERROR`. This patch modifies the `xdist.plugin.parse_numprocesses` to return the "auto" value if the input string exceeds the number that is detected. 

I can add to the CHANGELOG for towncrier if this is an acceptable patch. It wasn't clear if this was an intentional optional override for other purposes and a bias in my use case. Running `pytest` in a 3.7 environment passes the current tests, and I've added a new one.
