### PR TITLE
Use default with usepdb option

### DIFF
--- a/xdist/looponfail.py
+++ b/xdist/looponfail.py
@@ -30,7 +30,7 @@ def pytest_addoption(parser):
 def pytest_cmdline_main(config):
 
     if config.getoption("looponfail"):
-        usepdb = config.getoption("usepdb")  # a core option
+        usepdb = config.getoption("usepdb", False)  # a core option
         if usepdb:
             raise pytest.UsageError("--pdb is incompatible with --looponfail.")
         looponfail_main(config)

--- a/xdist/plugin.py
+++ b/xdist/plugin.py
@@ -181,7 +181,7 @@ def pytest_configure(config):
 
 @pytest.mark.tryfirst
 def pytest_cmdline_main(config):
-    usepdb = config.getoption("usepdb")  # a core option
+    usepdb = config.getoption("usepdb", False)  # a core option
     if isinstance(config.option.numprocesses, AutoInt):
         config.option.numprocesses = 0 if usepdb else int(config.option.numprocesses)
 


### PR DESCRIPTION
This is required with `-p no:debugging`.

Ref: https://github.com/pytest-dev/pytest/pull/4967.