### PR TITLE
Do not show internal error when running out of workers

### DIFF
--- a/changelog/435.bugfix.rst
+++ b/changelog/435.bugfix.rst
@@ -1,0 +1,1 @@
+No longer show an internal error when we run out of workers due to crashes.

--- a/changelog/435.feature.rst
+++ b/changelog/435.feature.rst
@@ -1,0 +1,2 @@
+When the test session is interrupted due to running out of workers, the reason is shown in the test summary
+for easier viewing.


### PR DESCRIPTION
Also show the reason of the session being interrupted
in the warnings summary

Fix #435
