### PR TITLE
Improve CI: drop testing pytest master on py27, use py37

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: black
         args: [--safe, --quiet]
-        language_version: python3.6
+        language_version: python3.7
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.3.0
     hooks:
@@ -21,4 +21,4 @@ repos:
         files: ^(CHANGELOG.rst|HOWTORELEASE.rst|README.rst|changelog/.*)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
-        python_version: python3.6
+        python_version: python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
   - pytest-commit@python.org
 
 install:
-  - pip install -U pip
+  - pip install -U pip setuptools
   - pip install tox setuptools_scm
 script: tox
 
@@ -25,13 +25,13 @@ stages:
 jobs:
   include:
     - stage: baseline
-      python: '3.6'
+      python: '3.7'
       env: TOXENV=linting
       cache:
         directories:
           - $HOME/.cache/pre-commit
-    - python: '3.6'
-      env: TOXENV=py36-pytestlatest
+    - python: '3.7'
+      env: TOXENV=py37-pytestlatest
     - python: '2.7'
       env: TOXENV=py27-pytestlatest
 
@@ -40,19 +40,15 @@ jobs:
       env: TOXENV=py34-pytestlatest
     - python: "3.5"
       env: TOXENV=py35-pytestlatest
+    - python: "3.6"
+      env: TOXENV=py36-pytestlatest
     - python: "3.7"
-      env: TOXENV=py37-pytestlatest
-    - python: "2.7"
-      env: TOXENV=py27-pytestmaster
-    - python: "2.7"
-      env: TOXENV=py27-pytestfeatures
-    - python: "3.6"
-      env: TOXENV=py36-pytestmaster
-    - python: "3.6"
-      env: TOXENV=py36-pytestfeatures
+      env: TOXENV=py37-pytestmaster
+    - python: "3.7"
+      env: TOXENV=py37-pytestfeatures
 
     - stage: deploy
-      python: '3.6'
+      python: '3.7'
       env:
       install: pip install -U setuptools setuptools_scm
       script: skip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,11 @@ environment:
   - TOXENV: "py35-pytestlatest"
   - TOXENV: "py36-pytestlatest"
   - TOXENV: "py37-pytestlatest"
-  - TOXENV: "py27-pytestmaster"
-  - TOXENV: "py36-pytestmaster"
-  - TOXENV: "py27-pytestfeatures"
-  - TOXENV: "py36-pytestfeatures"
+  - TOXENV: "py37-pytestmaster"
+  - TOXENV: "py37-pytestfeatures"
 
 install:
-  - C:\Python37\python -m pip install -U pip
+  - C:\Python37\python -m pip install -U pip setuptools
   - C:\Python37\python -m pip install -U tox setuptools_scm
 
 build: false  # Not a C# project, build stuff at the test step instead.

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
   linting
   py{27,34,35,36,37}-pytestlatest
-  py{27,36}-pytest{master,features}
+  py37-pytest{master,features}
 
 [testenv]
 passenv = USER USERNAME
@@ -24,7 +24,7 @@ commands = pre-commit run --all-files --show-diff-on-failure
 [testenv:release]
 changedir=
 decription = do a release, required posarg of the version number
-basepython = python3.6
+basepython = python3.7
 skipsdist = True
 usedevelop = True
 passenv = *


### PR DESCRIPTION
* Use Python 3.7 as preferred Python 3 interpreter
* Do not test pytest `master` and `features` branches on
  Python 2.7, as those branches no longer support Python 2.7/3.4

