### PR TITLE
Use Config.invocation_params for consistent worker initialization

### DIFF
--- a/changelog/448.feature.rst
+++ b/changelog/448.feature.rst
@@ -1,0 +1,9 @@
+Initialization between workers and master nodes is now more consistent, which fixes a number of
+long-standing issues related to startup with the ``-c`` option.
+
+Issues:
+
+* `#6 <https://github.com/pytest-dev/pytest-xdist/issues/6>`__: Poor interaction between ``-n#`` and ``-c X.cfg``
+* `#445 <https://github.com/pytest-dev/pytest-xdist/issues/445>`__: pytest-xdist is not reporting the same nodeid as pytest does
+
+This however only works with **pytest 5.1 or later**, as it required changes in pytest itself.

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -186,6 +186,8 @@ def make_reltoroot(roots, args):
     for arg in args:
         parts = arg.split(splitcode)
         fspath = py.path.local(parts[0])
+        if not fspath.exists():
+            continue
         for root in roots:
             x = fspath.relto(root)
             if x or fspath == root:
@@ -236,10 +238,14 @@ class WorkerController(object):
     def setup(self):
         self.log("setting up worker session")
         spec = self.gateway.spec
-        args = self.config.args
+        if hasattr(self.config, "invocation_params"):
+            args = [str(x) for x in self.config.invocation_params.args or ()]
+            option_dict = {}
+        else:
+            args = self.config.args
+            option_dict = vars(self.config.option)
         if not spec.popen or spec.chdir:
             args = make_reltoroot(self.nodemanager.roots, args)
-        option_dict = vars(self.config.option)
         if spec.popen:
             name = "popen-%s" % self.gateway.id
             if hasattr(self.config, "_tmpdirhandler"):


### PR DESCRIPTION
**EDIT**

Decided to keep the old way still working for now.

Fix #6
Fix #445

---

**ORIGINAL POST**

While investigating a recent node id bug (#445) I decided to play
with config initialization, around the idea of initializing the config
on the remote *exactly* how we initialize the config object on pytest.main()

One thing that immediately broke all tests was *inprocess* pytester runs,
but other than that just a few tests failed which I find encouraging.

While this patch is in no way even remotely ready, I would like to get
opinions if the overall idea of initializing the config object
like this is sound.
