### PR TITLE
Fix issues related to running xdist with the terminal plugin disabled

### DIFF
--- a/changelog/467.bugfix.rst
+++ b/changelog/467.bugfix.rst
@@ -1,0 +1,1 @@
+Fix crash issues related to running xdist with the terminal plugin disabled.

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -49,11 +49,8 @@ class DSession(object):
         self._max_worker_restart = get_default_max_worker_restart(self.config)
         # summary message to print at the end of the session
         self._summary_report = None
-        try:
-            self.terminal = config.pluginmanager.getplugin("terminalreporter")
-        except KeyError:
-            self.terminal = None
-        else:
+        self.terminal = config.pluginmanager.getplugin("terminalreporter")
+        if self.terminal:
             self.trdist = TerminalDistReporter(config)
             config.pluginmanager.register(self.trdist, "terminaldistreporter")
 

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -170,7 +170,8 @@ def pytest_configure(config):
         session = DSession(config)
         config.pluginmanager.register(session, "dsession")
         tr = config.pluginmanager.getplugin("terminalreporter")
-        tr.showfspath = False
+        if tr:
+            tr.showfspath = False
     if config.getoption("boxed"):
         config.option.forked = True
 

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -112,7 +112,10 @@ class NodeManager(object):
         ignores += self.config.option.rsyncignore
         ignores += self.config.getini("rsyncignore")
 
-        return {"ignores": ignores, "verbose": self.config.option.verbose}
+        return {
+            "ignores": ignores,
+            "verbose": getattr(self.config.option, "verbose", False),
+        }
 
     def rsync(self, gateway, source, notify=None, verbose=False, ignores=None):
         """Perform rsync to remote hosts for node."""

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1087,6 +1087,7 @@ def test_without_terminal_plugin(testdir, request):
     result = testdir.runpytest("-p", "no:terminal", "-n2")
     assert result.stdout.str() == ""
     assert result.stderr.str() == ""
+    assert result.ret == 0
 
 
 def test_internal_error_with_maxfail(testdir):

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1074,6 +1074,21 @@ def test_color_yes_collection_on_non_atty(testdir, request):
     assert "gw0 C / gw1 C" not in result.stdout.str()
 
 
+def test_without_terminal_plugin(testdir, request):
+    """
+    No output when terminal plugin is disabled
+    """
+    testdir.makepyfile(
+        """
+        def test_1():
+            pass
+    """
+    )
+    result = testdir.runpytest("-p", "no:terminal", "-n2")
+    assert result.stdout.str() == ""
+    assert result.stderr.str() == ""
+
+
 def test_internal_error_with_maxfail(testdir):
     """
     Internal error when using --maxfail option (#62, #65).


### PR DESCRIPTION
This fixes an issue where the pluggy plugin manager returns None if a plugin is not loaded instead of raising an error.
It also makes terminal optional in plugin code.