### PR TITLE
tests: check that PYTEST_ADDOPTS is not processed twice

### DIFF
--- a/changelog/478.bugfix.rst
+++ b/changelog/478.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression with duplicated arguments via $PYTEST_ADDOPTS in 1.30.0.

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -593,6 +593,10 @@ def test_fixture_teardown_failure(testdir):
     assert result.ret
 
 
+@pytest.mark.skipif(
+    sys.version_info[:2] == (2, 7),
+    reason="Only available in pytest 5.0+ (Python 3 only)",
+)
 def test_config_initialization(testdir, monkeypatch, pytestconfig):
     """Ensure workers and master are initialized consistently. Integration test for #445"""
     if not hasattr(pytestconfig, "invocation_params"):


### PR DESCRIPTION
Since 953a3f0 options are parsed already, e.g. "-v" from
`$PYTEST_ADDOPTS`, and therefore `$PYTEST_ADDOPTS` should be unset for
child processes.