### PR TITLE
Move checking of options to pytest_configure

### DIFF
--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -164,6 +164,8 @@ def pytest_addhooks(pluginmanager):
 
 @pytest.mark.trylast
 def pytest_configure(config):
+    _check_options(config)
+
     if config.getoption("dist") != "no" and not config.getvalue("collectonly"):
         from xdist.dsession import DSession
 
@@ -176,8 +178,8 @@ def pytest_configure(config):
         config.option.forked = True
 
 
-@pytest.mark.tryfirst
-def pytest_cmdline_main(config):
+def _check_options(config):
+    """Kept separate for tests."""
     usepdb = config.getoption("usepdb", False)  # a core option
     if isinstance(config.option.numprocesses, AutoInt):
         config.option.numprocesses = 0 if usepdb else int(config.option.numprocesses)

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -164,22 +164,6 @@ def pytest_addhooks(pluginmanager):
 
 @pytest.mark.trylast
 def pytest_configure(config):
-    _check_options(config)
-
-    if config.getoption("dist") != "no" and not config.getvalue("collectonly"):
-        from xdist.dsession import DSession
-
-        session = DSession(config)
-        config.pluginmanager.register(session, "dsession")
-        tr = config.pluginmanager.getplugin("terminalreporter")
-        if tr:
-            tr.showfspath = False
-    if config.getoption("boxed"):
-        config.option.forked = True
-
-
-def _check_options(config):
-    """Kept separate for tests."""
     usepdb = config.getoption("usepdb", False)  # a core option
     if isinstance(config.option.numprocesses, AutoInt):
         config.option.numprocesses = 0 if usepdb else int(config.option.numprocesses)
@@ -200,6 +184,17 @@ def _check_options(config):
                 raise pytest.UsageError(
                     "--pdb is incompatible with distributing tests; try using -n0 or -nauto."
                 )  # noqa: E501
+
+    if config.getoption("dist") != "no" and not config.getvalue("collectonly"):
+        from xdist.dsession import DSession
+
+        session = DSession(config)
+        config.pluginmanager.register(session, "dsession")
+        tr = config.pluginmanager.getplugin("terminalreporter")
+        if tr:
+            tr.showfspath = False
+    if config.getoption("boxed"):
+        config.option.forked = True
 
 
 # -------------------------------------------------------------------------

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -1,5 +1,6 @@
 import py
 import execnet
+from xdist.plugin import _check_options as check_options
 from xdist.workermanage import NodeManager
 
 
@@ -21,8 +22,6 @@ def test_pdb_can_be_used_before_configure(testdir):
 
 
 def test_dist_options(testdir):
-    from xdist.plugin import pytest_cmdline_main as check_options
-
     config = testdir.parseconfigure("-n 2")
     check_options(config)
     assert config.option.dist == "load"
@@ -42,7 +41,6 @@ def test_dist_options(testdir):
 
 def test_auto_detect_cpus(testdir, monkeypatch):
     import os
-    from xdist.plugin import pytest_cmdline_main as check_options
 
     if hasattr(os, "sched_getaffinity"):
         monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(99)))
@@ -71,8 +69,6 @@ def test_auto_detect_cpus(testdir, monkeypatch):
 
 
 def test_boxed_with_collect_only(testdir):
-    from xdist.plugin import pytest_cmdline_main as check_options
-
     config = testdir.parseconfigure("-n1", "--boxed")
     check_options(config)
     assert config.option.forked
@@ -87,17 +83,10 @@ def test_boxed_with_collect_only(testdir):
 
 
 def test_dsession_with_collect_only(testdir):
-    from xdist.plugin import pytest_cmdline_main as check_options
-    from xdist.plugin import pytest_configure as configure
-
     config = testdir.parseconfigure("-n1")
-    check_options(config)
-    configure(config)
     assert config.pluginmanager.hasplugin("dsession")
 
     config = testdir.parseconfigure("-n1", "--collect-only")
-    check_options(config)
-    configure(config)
     assert not config.pluginmanager.hasplugin("dsession")
 
 

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -14,6 +14,12 @@ def test_dist_incompatibility_messages(testdir):
     assert "incompatible" in result.stderr.str()
 
 
+def test_pdb_can_be_used_before_configure(testdir):
+    result = testdir.runpytest("--pdb", "-n", "2", "--version")
+    assert result.ret == 0
+    assert "pytest version" in result.stderr.str()
+
+
 def test_dist_options(testdir):
     from xdist.plugin import pytest_cmdline_main as check_options
 

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -1,6 +1,5 @@
 import py
 import execnet
-from xdist.plugin import _check_options as check_options
 from xdist.workermanage import NodeManager
 
 
@@ -23,19 +22,15 @@ def test_pdb_can_be_used_before_configure(testdir):
 
 def test_dist_options(testdir):
     config = testdir.parseconfigure("-n 2")
-    check_options(config)
     assert config.option.dist == "load"
     assert config.option.tx == ["popen"] * 2
     config = testdir.parseconfigure("--numprocesses", "2")
-    check_options(config)
     assert config.option.dist == "load"
     assert config.option.tx == ["popen"] * 2
     config = testdir.parseconfigure("--numprocesses", "3", "--maxprocesses", "2")
-    check_options(config)
     assert config.option.dist == "load"
     assert config.option.tx == ["popen"] * 2
     config = testdir.parseconfigure("-d")
-    check_options(config)
     assert config.option.dist == "load"
 
 
@@ -58,7 +53,6 @@ def test_auto_detect_cpus(testdir, monkeypatch):
     assert config.getoption("numprocesses") == 99
 
     config = testdir.parseconfigure("-nauto", "--pdb")
-    check_options(config)
     assert config.getoption("usepdb")
     assert config.getoption("numprocesses") == 0
 
@@ -70,15 +64,12 @@ def test_auto_detect_cpus(testdir, monkeypatch):
 
 def test_boxed_with_collect_only(testdir):
     config = testdir.parseconfigure("-n1", "--boxed")
-    check_options(config)
     assert config.option.forked
 
     config = testdir.parseconfigure("-n1", "--collect-only")
-    check_options(config)
     assert not config.option.forked
 
     config = testdir.parseconfigure("-n1", "--boxed", "--collect-only")
-    check_options(config)
     assert config.option.forked
 
 


### PR DESCRIPTION
This allows for `pytest -n 2 --pdb` to stop / help with errors
before/during `pytest_configure`.
It also appears to be sensible to check the config in the hook meant for
it, instead of in `pytest_cmdline_main`.

TODO (after approval):

- [ ] changelog