### PR TITLE
Remove handling of pytest_logwarning

### DIFF
--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -271,11 +271,6 @@ class DSession(object):
         assert not rep.passed
         self._failed_worker_collectreport(node, rep)
 
-    def worker_logwarning(self, message, code, nodeid, fslocation):
-        """Emitted when a node calls the pytest_logwarning hook."""
-        kwargs = dict(message=message, code=code, nodeid=nodeid, fslocation=fslocation)
-        self.config.hook.pytest_logwarning.call_historic(kwargs=kwargs)
-
     def worker_warning_captured(self, warning_message, when, item):
         """Emitted when a node calls the pytest_logwarning hook."""
         kwargs = dict(warning_message=warning_message, when=when, item=item)

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -123,20 +123,6 @@ class WorkerInteractor(object):
             )
             self.sendevent("collectreport", data=data)
 
-    # the pytest_logwarning hook was deprecated since pytest 4.0
-    if hasattr(
-        _pytest.hookspec, "pytest_logwarning"
-    ) and not _pytest.hookspec.pytest_logwarning.pytest_spec.get("warn_on_impl"):
-
-        def pytest_logwarning(self, message, code, nodeid, fslocation):
-            self.sendevent(
-                "logwarning",
-                message=message,
-                code=code,
-                nodeid=nodeid,
-                fslocation=str(fslocation),
-            )
-
     # the pytest_warning_captured hook was introduced in pytest 3.8
     if hasattr(_pytest.hookspec, "pytest_warning_captured"):
 

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -340,14 +340,6 @@ class WorkerController(object):
                 self.notify_inproc(eventname, node=self, ids=kwargs["ids"])
             elif eventname == "runtest_protocol_complete":
                 self.notify_inproc(eventname, node=self, **kwargs)
-            elif eventname == "logwarning":
-                self.notify_inproc(
-                    eventname,
-                    message=kwargs["message"],
-                    code=kwargs["code"],
-                    nodeid=kwargs["nodeid"],
-                    fslocation=kwargs["nodeid"],
-                )
             elif eventname == "warning_captured":
                 warning_message = unserialize_warning_message(
                     kwargs["warning_message_data"]


### PR DESCRIPTION
This was deprecated since pytest 4.0 (and not being called there for
later versions anymore, c5f65b39e).
By now pytest 4.4 is required (since 89d07a5), so it can be removed.

TODO:

- [ ] changelog?