### PR TITLE
Fix passing `--basetemp` to subprocesses with pytest 5.4

### DIFF
--- a/changelog/510.bugfix.rst
+++ b/changelog/510.bugfix.rst
@@ -1,0 +1,1 @@
+Fix passing `--basetemp` to subprocesses with pytest 5.4.

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -1,12 +1,14 @@
 from __future__ import print_function
+
 import fnmatch
 import os
 import re
 import sys
 
+import execnet
 import py
 import pytest
-import execnet
+from _pytest.tmpdir import TempPathFactory
 
 import xdist.remote
 
@@ -252,9 +254,9 @@ class WorkerController(object):
             args = make_reltoroot(self.nodemanager.roots, args)
         if spec.popen:
             name = "popen-%s" % self.gateway.id
-            if hasattr(self.config, "_tmpdirhandler"):
-                basetemp = self.config._tmpdirhandler.getbasetemp()
-                option_dict["basetemp"] = str(basetemp.join(name))
+            basetemp = TempPathFactory.from_config(self.config).getbasetemp()
+            option_dict["basetemp"] = str(basetemp.joinpath(name))
+
         self.config.hook.pytest_configure_node(node=self)
 
         remote_module = self.config.hook.pytest_xdist_getremotemodule()

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -766,9 +766,11 @@ def test_tmpdir_disabled(testdir):
     """
     p1 = testdir.makepyfile(
         """
-        def test_ok():
-            pass
-    """
+        def test_ok(request):
+            assert request.config.option.basetemp == {!r}
+    """.format(
+            str(testdir.tmpdir.dirpath() / "basetemp" / "popen-gw0")
+        )
     )
     result = testdir.runpytest(p1, "-n1", "-p", "no:tmpdir")
     assert result.ret == 0

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -122,11 +122,22 @@ class TestDistribution:
 
             def test_send1(tmpdir):
                 assert tmpdir.relto(py.path.local({!r})), tmpdir
+                assert str(tmpdir) == {!r}
 
             def test_send2(tmpdir):
                 assert tmpdir.relto(py.path.local({!r})), tmpdir
+                assert str(tmpdir) == {!r}
         """.format(
-                str(testdir.tmpdir), str(testdir.tmpdir),
+                str(testdir.tmpdir),
+                str(
+                    testdir.tmpdir.dirpath()
+                    / "test_basetemp_in_subprocesses0/runpytest-0/popen-gw0/test_send10"
+                ),
+                str(testdir.tmpdir),
+                str(
+                    testdir.tmpdir.dirpath()
+                    / "test_basetemp_in_subprocesses0/runpytest-0/popen-gw1/test_send20"
+                ),
             )
         )
         result = testdir.runpytest_subprocess(p1, "-n2")


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest-xdist/issues/510.
Ref: https://github.com/pytest-dev/pytest/pull/6767

Also uses `--basetemp` with `-p no:tmpdir` as a good side effect
(ref: https://github.com/pytest-dev/pytest-xdist/issues/22).

Current failure with py27 due to 4.6.x missing https://github.com/pytest-dev/pytest/commit/3e669a262 (https://github.com/pytest-dev/pytest/pull/6870).