### PR TITLE
Use 'getoption'  to get the basetemp value instead of private details

### DIFF
--- a/changelog/518.bugfix
+++ b/changelog/518.bugfix
@@ -1,0 +1,1 @@
+Fix support of the `--basetemp` pytest option for pytest 5.4.0 and up.

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -252,9 +252,9 @@ class WorkerController(object):
             args = make_reltoroot(self.nodemanager.roots, args)
         if spec.popen:
             name = "popen-%s" % self.gateway.id
-            if hasattr(self.config, "_tmpdirhandler"):
-                basetemp = self.config._tmpdirhandler.getbasetemp()
-                option_dict["basetemp"] = str(basetemp.join(name))
+            basetemp = self.config.getoption("basetemp")
+            if basetemp is not None:
+                option_dict["basetemp"] = str(os.path.join(basetemp, name))
         self.config.hook.pytest_configure_node(node=self)
 
         remote_module = self.config.hook.pytest_xdist_getremotemodule()

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -128,6 +128,22 @@ class TestDistribution:
         assert result.ret == 0
         result.stdout.fnmatch_lines(["*1 passed*"])
 
+    def test_basetemp_in_subprocesses_when_specified(self, testdir):
+        basetemp = testdir.tmpdir.join("one-level-down")
+        basetemp.mkdir()
+
+        p1 = testdir.makepyfile(
+            """
+            def test_send(tmpdir):
+                import py
+                assert tmpdir.relto(py.path.local(%r)), tmpdir
+        """
+            % str(basetemp)
+        )
+        result = testdir.runpytest_subprocess(p1, "-n1", "--basetemp", basetemp)
+        assert result.ret == 0
+        result.stdout.fnmatch_lines(["*1 passed*"])
+
     def test_dist_ini_specified(self, testdir):
         p1 = testdir.makepyfile(
             """


### PR DESCRIPTION
https://github.com/pytest-dev/pytest/pull/6767 has removed the `_tmpdirhandler` that was used to get the base temporary directory.

This now reads the path to the base temporary directory directly
from pytest configuration.

Fix #518 

--- 
Here's a quick checklist that should be present in PRs:

- [X] Make sure to include reasonable tests for your change if necessary

- [X] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
