### PR TITLE
Add global testrun uid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -309,7 +309,7 @@ wanted to create a separate database for each test run:
 
 Additionally, during a test run, the following environment variable is defined:
 
-* ``PYTEST_XDIST_TESTRUNUID`: the unique id of the test run
+* ``PYTEST_XDIST_TESTRUNUID``: the unique id of the test run.
 
 Acessing ``sys.argv`` from the master node in workers
 -----------------------------------------------------

--- a/changelog/524.feature
+++ b/changelog/524.feature
@@ -1,0 +1,2 @@
+Add `testrun_uid` fixture. This is a shared value that uniquely identifies a test run among all workers.
+This also adds a `PYTEST_XDIST_TESTRUNUID` environment variable that is accessible within a test as well as a command line option `--testrunuid` to manually set the value from outside.

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 import py
 import pytest
@@ -122,12 +123,22 @@ def pytest_addoption(parser):
         metavar="GLOB",
         help="add expression for ignores when rsyncing to remote tx nodes.",
     )
-
     group.addoption(
         "--boxed",
         action="store_true",
         help="backward compatibility alias for pytest-forked --forked",
     )
+    group.addoption(
+        "--testrunuid",
+        action="store",
+        help=(
+            "provide an identifier shared amongst all workers as the value of "
+            "the 'testrun_uid' fixture,\n\n,"
+            "if not provided, 'testrun_uid' is filled with a new unique string "
+            "on every test run."
+        ),
+    )
+
     parser.addini(
         "rsyncdirs",
         "list of (relative) paths to be rsynced for remote distributed testing.",
@@ -214,3 +225,12 @@ def worker_id(request):
         return request.config.workerinput["workerid"]
     else:
         return "master"
+
+
+@pytest.fixture(scope="session")
+def testrun_uid(request):
+    """Return the unique id of the current test."""
+    if hasattr(request.config, "workerinput"):
+        return request.config.workerinput["testrunuid"]
+    else:
+        return uuid.uuid4().hex

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -22,6 +22,7 @@ class WorkerInteractor(object):
     def __init__(self, config, channel):
         self.config = config
         self.workerid = config.workerinput.get("workerid", "?")
+        self.testrunuid = config.workerinput["testrunuid"]
         self.log = py.log.Producer("worker-%s" % self.workerid)
         if not config.option.debug:
             py.log.setconsumer(self.log._keywords, None)
@@ -112,6 +113,7 @@ class WorkerInteractor(object):
         )
         data["item_index"] = self.item_index
         data["worker_id"] = self.workerid
+        data["testrun_uid"] = self.testrunuid
         assert self.session.items[self.item_index].nodeid == report.nodeid
         self.sendevent("testreport", data=data)
 
@@ -238,6 +240,7 @@ if __name__ == "__channelexec__":
             importpath + os.pathsep + os.environ.get("PYTHONPATH", "")
         )
 
+    os.environ["PYTEST_XDIST_TESTRUNUID"] = workerinput["testrunuid"]
     os.environ["PYTEST_XDIST_WORKER"] = workerinput["workerid"]
     os.environ["PYTEST_XDIST_WORKER_COUNT"] = str(workerinput["workercount"])
 

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -3,6 +3,7 @@ import fnmatch
 import os
 import re
 import sys
+import uuid
 
 import py
 import pytest
@@ -35,6 +36,9 @@ class NodeManager(object):
     def __init__(self, config, specs=None, defaultchdir="pyexecnetcache"):
         self.config = config
         self.trace = self.config.trace.get("nodemanager")
+        self.testrunuid = self.config.getoption("testrunuid")
+        if self.testrunuid is None:
+            self.testrunuid = uuid.uuid4().hex
         self.group = execnet.Group()
         if specs is None:
             specs = self._getxspecs()
@@ -222,6 +226,7 @@ class WorkerController(object):
             "workercount": len(nodemanager.specs),
             "slaveid": gateway.id,
             "slavecount": len(nodemanager.specs),
+            "testrunuid": nodemanager.testrunuid,
             "mainargv": sys.argv,
         }
         # TODO: deprecated name, backward compatibility only. Remove it in future

--- a/testing/test_newhooks.py
+++ b/testing/test_newhooks.py
@@ -15,7 +15,7 @@ class TestHooks:
 
     def test_runtest_logreport(self, testdir):
         """Test that log reports from pytest_runtest_logreport when running
-        with xdist contain "node", "nodeid" and "worker_id" attributes. (#8)
+        with xdist contain "node", "nodeid", "worker_id", and "testrun_uid" attributes. (#8)
         """
         testdir.makeconftest(
             """
@@ -23,20 +23,24 @@ class TestHooks:
                 if hasattr(report, 'node'):
                     if report.when == "call":
                         workerid = report.node.workerinput['workerid']
+                        testrunuid = report.node.workerinput['testrunuid']
                         if workerid != report.worker_id:
                             print("HOOK: Worker id mismatch: %s %s"
                                    % (workerid, report.worker_id))
+                        elif testrunuid != report.testrun_uid:
+                            print("HOOK: Testrun uid mismatch: %s %s"
+                                   % (testrunuid, report.testrun_uid))
                         else:
-                            print("HOOK: %s %s"
-                                   % (report.nodeid, report.worker_id))
+                            print("HOOK: %s %s %s"
+                                   % (report.nodeid, report.worker_id, report.testrun_uid))
         """
         )
         res = testdir.runpytest("-n1", "-s")
         res.stdout.fnmatch_lines(
             [
-                "*HOOK: test_runtest_logreport.py::test_a gw0*",
-                "*HOOK: test_runtest_logreport.py::test_b gw0*",
-                "*HOOK: test_runtest_logreport.py::test_c gw0*",
+                "*HOOK: test_runtest_logreport.py::test_a gw0 *",
+                "*HOOK: test_runtest_logreport.py::test_b gw0 *",
+                "*HOOK: test_runtest_logreport.py::test_c gw0 *",
                 "*3 passed*",
             ]
         )

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -95,6 +95,18 @@ def test_dsession_with_collect_only(testdir):
     assert not config.pluginmanager.hasplugin("dsession")
 
 
+def test_testrunuid_provided(testdir):
+    config = testdir.parseconfigure("--testrunuid", "test123", "--tx=popen")
+    nm = NodeManager(config)
+    assert nm.testrunuid == "test123"
+
+
+def test_testrunuid_generated(testdir):
+    config = testdir.parseconfigure("--tx=popen")
+    nm = NodeManager(config)
+    assert len(nm.testrunuid) == 32
+
+
 class TestDistOptions:
     def test_getxspecs(self, testdir):
         config = testdir.parseconfigure("--tx=popen", "--tx", "ssh=xyz")

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -2,6 +2,7 @@ import py
 import pprint
 import pytest
 import sys
+import uuid
 
 from xdist.workermanage import WorkerController
 import execnet
@@ -44,6 +45,7 @@ class WorkerSetup:
         putevent = self.use_callback and self.events.put or None
 
         class DummyMananger:
+            testrunuid = uuid.uuid4().hex
             specs = [0, 1]
 
         self.slp = WorkerController(DummyMananger, self.gateway, config, putevent)
@@ -220,6 +222,7 @@ def test_remote_env_vars(testdir):
         """
         import os
         def test():
+            assert len(os.environ['PYTEST_XDIST_TESTRUNUID']) == 32
             assert os.environ['PYTEST_XDIST_WORKER'] in ('gw0', 'gw1')
             assert os.environ['PYTEST_XDIST_WORKER_COUNT'] == '2'
     """


### PR DESCRIPTION
This fixes my own itch #524. I think this is a very useful and simple global pre-shared state variable for some configurations.

- [x] Make sure to include reasonable tests for your change if necessary

- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```