### PR TITLE
Ignore Python 3.8 specific failure in pytest for now

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -115,6 +115,9 @@ class TestDistribution:
         assert result.ret == 2
         result.stdout.fnmatch_lines(["*Interrupted: stopping*1*", "*1 failed*"])
 
+    @pytest.mark.xfail(
+        reason="#527: Python 3.8 failure in pytest where testdir.tmpdir returns an unexpected value"
+    )
     def test_basetemp_in_subprocesses(self, testdir):
         p1 = testdir.makepyfile(
             """
@@ -186,6 +189,7 @@ class TestDistribution:
         )
         assert result.ret == 1
 
+    @pytest.mark.xfail(reason="#527: Ignore Python 3.8 failure for the time being")
     def test_distribution_rsyncdirs_example(self, testdir, monkeypatch):
         # use a custom plugin that has a custom command-line option to ensure
         # this is propagated to workers (see #491)


### PR DESCRIPTION
I suggest we xmark these tests for the time being until pytest upstream issues are resolved.

The failure of `testdir.tmpdir` on Python 2 is

`/tmp/pytest-of-svenstaro/pytest-326/test_basetemp_in_subprocesses0/runpytest-0/popen-gw0/test_send0`

while in Python 3 it is 

`/tmp/pytest-of-svenstaro/pytest-327/tmp-test_basetemp_in_subprocesses0/pytest-of-svenstaro/pytest-0/test_send0`

It's not an optimal fix but at least we'll be able to more easily notice actual test failure in `pytest-xdist`-specific code again. Currently, everything just fails which isn't optimal.