### PR TITLE
Simplify failure deduplication in looponfail

### DIFF
--- a/src/xdist/looponfail.py
+++ b/src/xdist/looponfail.py
@@ -120,11 +120,7 @@ class RemoteControl(object):
         if collection_failed:
             pass  # "Collection failed, keeping previous failure set"
         else:
-            uniq_failures = []
-            for failure in failures:
-                if failure not in uniq_failures:
-                    uniq_failures.append(failure)
-            self.failures = uniq_failures
+            self.failures = list(set(failures))
 
 
 def repr_pytest_looponfailinfo(failreports, rootdirs):


### PR DESCRIPTION
This PR simplifies deduplication of failures in `looponfail` using `set` instead of iterating over all failures. This should simplify the code and in general might be a bit faster as well.