### PR TITLE
Exclude SCM and CI files from distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+exclude .appveyor.yml
+exclude .gitignore
+exclude .pre-commit-config.yaml
+exclude .travis.yml
+prune .github


### PR DESCRIPTION
These files don't make sense outside of the git respository.
