### PR TITLE
Fix compatibility with pytest master

### DIFF
--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -277,9 +277,16 @@ class DSession(object):
         self.config.hook.pytest_logwarning.call_historic(kwargs=kwargs)
 
     def worker_warning_captured(self, warning_message, when, item):
-        """Emitted when a node calls the pytest_logwarning hook."""
+        """Emitted when a node calls the pytest_warning_captured hook (deprecated in 6.0)."""
         kwargs = dict(warning_message=warning_message, when=when, item=item)
         self.config.hook.pytest_warning_captured.call_historic(kwargs=kwargs)
+
+    def worker_warning_recorded(self, warning_message, when, nodeid, location):
+        """Emitted when a node calls the pytest_warning_recorded hook."""
+        kwargs = dict(
+            warning_message=warning_message, when=when, nodeid=nodeid, location=location
+        )
+        self.config.hook.pytest_warning_recorded.call_historic(kwargs=kwargs)
 
     def _clone_node(self, node):
         """Return new node based on an existing one.

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -151,6 +151,18 @@ class WorkerInteractor(object):
                 item=None,
             )
 
+    # the pytest_warning_recorded hook was introduced in pytest 6.0
+    if hasattr(_pytest.hookspec, "pytest_warning_recorded"):
+
+        def pytest_warning_recorded(self, warning_message, when, nodeid, location):
+            self.sendevent(
+                "warning_recorded",
+                warning_message_data=serialize_warning_message(warning_message),
+                when=when,
+                nodeid=nodeid,
+                location=location,
+            )
+
 
 def serialize_warning_message(warning_message):
     if isinstance(warning_message.message, Warning):

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -359,6 +359,17 @@ class WorkerController(object):
                     when=kwargs["when"],
                     item=kwargs["item"],
                 )
+            elif eventname == "warning_recorded":
+                warning_message = unserialize_warning_message(
+                    kwargs["warning_message_data"]
+                )
+                self.notify_inproc(
+                    eventname,
+                    warning_message=warning_message,
+                    when=kwargs["when"],
+                    nodeid=kwargs["nodeid"],
+                    location=kwargs["location"],
+                )
             else:
                 raise ValueError("unknown event: {}".format(eventname))
         except KeyboardInterrupt:

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -22,12 +22,16 @@ def _divert_atexit(request, monkeypatch):
 
     finalizers = []
 
-    def finish():
-        while finalizers:
-            finalizers.pop()()
+    def fake_register(func, *args, **kwargs):
+        finalizers.append((func, args, kwargs))
 
-    monkeypatch.setattr(atexit, "register", finalizers.append)
-    request.addfinalizer(finish)
+    monkeypatch.setattr(atexit, "register", fake_register)
+
+    yield
+
+    while finalizers:
+        func, args, kwargs = finalizers.pop()
+        func(*args, **kwargs)
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
* Fix the autouse fixture which diverts atexit.register calls to support the correct signature.
* Support the new `pytest_warning_recorded` hook.

