### PR TITLE
Fix rsyncdirs usage with pytest 6.0

### DIFF
--- a/changelog/558.bugfix.rst
+++ b/changelog/558.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``rsyncdirs`` usage with pytest 6.0.

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -90,8 +90,16 @@ class NodeManager(object):
         import pytest
         import _pytest
 
-        pytestpath = pytest.__file__.rstrip("co")
-        pytestdir = py.path.local(_pytest.__file__).dirpath()
+        def get_dir(p):
+            """Return the directory path if p is a package or the path to the .py file otherwise."""
+            stripped = p.rstrip("co")
+            if os.path.basename(stripped) == "__init__.py":
+                return os.path.dirname(p)
+            else:
+                return stripped
+
+        pytestpath = get_dir(pytest.__file__)
+        pytestdir = get_dir(_pytest.__file__)
         config = self.config
         candidates = [py._pydir, pytestpath, pytestdir]
         candidates += config.option.rsyncdir

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -189,7 +189,6 @@ class TestDistribution:
         )
         assert result.ret == 1
 
-    @pytest.mark.xfail(reason="#527: Ignore Python 3.8 failure for the time being")
     def test_distribution_rsyncdirs_example(self, testdir, monkeypatch):
         # use a custom plugin that has a custom command-line option to ensure
         # this is propagated to workers (see #491)


### PR DESCRIPTION
Fix pytest-dev/pytest#7487
