### PR TITLE
Fix test_config_initialization condition for pytest<5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ jobs:
       env: TOXENV=py36-pytestlatest
     - python: "3.7"
       env: TOXENV=py37-pytestlatest
+    - python: "3.9-dev"
+      env: TOXENV=py39-pytestlatest
     - python: "3.8"
       env: TOXENV=py38-pytestmaster
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ jobs:
     - python: "3.9-dev"
       env: TOXENV=py39-pytestlatest
     - python: "3.8"
+      env: TOXENV=py38-pytest4
+    - python: "3.8"
+      env: TOXENV=py38-pytest5
+    - python: "3.8"
       env: TOXENV=py38-pytestmaster
 
     - stage: deploy

--- a/changelog/566.bugfix
+++ b/changelog/566.bugfix
@@ -1,0 +1,1 @@
+Fix test_config_initialization not being skipped correctly on pytest-4

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import textwrap
+from pkg_resources import parse_version
 
 import py
 import pytest
@@ -594,15 +595,11 @@ def test_fixture_teardown_failure(testdir):
 
 
 @pytest.mark.skipif(
-    sys.version_info[:2] == (2, 7),
-    reason="Only available in pytest 5.0+ (Python 3 only)",
+    parse_version(pytest.__version__) < parse_version("5"),
+    reason="Only available in pytest 5.0+",
 )
 def test_config_initialization(testdir, monkeypatch, pytestconfig):
     """Ensure workers and master are initialized consistently. Integration test for #445"""
-    if not hasattr(pytestconfig, "invocation_params"):
-        pytest.skip(
-            "requires pytest >=5.1 (config has no attribute 'invocation_params')"
-        )
     testdir.makepyfile(
         **{
             "dir_a/test_foo.py": """

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,16 @@
 [tox]
 envlist=
   linting
-  py{27,35,36,37,38,39}-pytestlatest
+  py{27,35,36,37,38,39}-pytest4
+  py{35,36,37,38,39}-pytest{5,latest}
   py38-pytestmaster
 
 [testenv]
 passenv = USER USERNAME
 extras = testing
 deps =
+  pytest4: pytest<5
+  pytest5: pytest<6
   pytestlatest: pytest
   pytestmaster: git+https://github.com/pytest-dev/pytest.git@master
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
   linting
-  py{27,35,36,37,38}-pytestlatest
+  py{27,35,36,37,38,39}-pytestlatest
   py38-pytestmaster
 
 [testenv]


### PR DESCRIPTION
Fix test_config_initialization to be correctly skipped on pytest<5,
by explicitly checking pytest version (idea copied from
test_looponfail_removed_test).  The current conditions are insufficient
-- the outer check wrongly assumes pytest>=5 will always be used
on Python 3 (which is not true if you need the same version to support
both Python 2 and Python 3), and the inner condition apparently
wrongly assuming that invocation_params attribute is not present
in pytest-4.

----

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
