### PR TITLE
[compat] Drop Python 2.x supports

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - TOXENV: "py27-pytestlatest"
   - TOXENV: "py35-pytestlatest"
   - TOXENV: "py36-pytestlatest"
   - TOXENV: "py37-pytestlatest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ jobs:
           - $HOME/.cache/pre-commit
     - python: '3.8'
       env: TOXENV=py38-pytestlatest
-    - python: '2.7'
-      env: TOXENV=py27-pytestlatest
 
     - stage: test
       python: "3.5"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ install_requires = [
     "psutil>=3.0.0",
     "pytest>=4.4.0",
     "pytest-forked",
-    "six",
 ]
 
 
@@ -30,7 +29,7 @@ setup(
         "pytest11": ["xdist = xdist.plugin", "xdist.looponfail = xdist.looponfail"]
     },
     zip_safe=False,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=3.5",
     install_requires=install_requires,
     setup_requires=["setuptools_scm"],
     classifiers=[
@@ -45,9 +44,7 @@ setup(
         "Topic :: Software Development :: Quality Assurance",
         "Topic :: Utilities",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,19 +1,8 @@
-import six
 import py
 import pytest
 import execnet
 
 pytest_plugins = "pytester"
-
-if six.PY2:
-
-    @pytest.fixture(scope="session", autouse=True)
-    def _ensure_imports():
-        # we import some modules because pytest-2.8's testdir fixture
-        # will unload all modules after each test and this cause
-        # (unknown) problems with execnet.Group()
-        execnet.Group
-        execnet.makegateway
 
 
 @pytest.fixture(autouse=True)

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -8,7 +8,7 @@ from xdist.workermanage import WorkerController
 import execnet
 import marshal
 
-from six.moves.queue import Queue
+from queue import Queue
 
 WAIT_TIMEOUT = 10.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
   linting
-  py{27,35,36,37,38}-pytestlatest
+  py{35,36,37,38}-pytestlatest
   py38-pytestmaster
 
 [testenv]


### PR DESCRIPTION
As pytest no longer supports Python 2.7, drop it from this package too

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [ ] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
