### PR TITLE
Prepare release 2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,34 @@
+pytest-xdist 2.0.0 (2020-08-12)
+===============================
+
+Deprecations and Removals
+-------------------------
+
+- `#541 <https://github.com/pytest-dev/pytest-xdist/issues/541>`_: Drop backward-compatibility "slave" aliases related to worker nodes.  We deliberately moved away from this terminology years ago, and it seems like the right time to finish the deprecation and removal process.
+
+- `#569 <https://github.com/pytest-dev/pytest-xdist/issues/569>`_: ``pytest-xdist`` no longer supports Python 2.7.
+
+
+Features
+--------
+
+- `#504 <https://github.com/pytest-dev/pytest-xdist/issues/504>`_: New functions ``xdist.is_xdist_worker``, ``xdist.is_xdist_master``, ``xdist.get_xdist_worker_id``, to easily identify the current node.
+
+
+Bug Fixes
+---------
+
+- `#471 <https://github.com/pytest-dev/pytest-xdist/issues/471>`_: Fix issue with Rsync reporting in quiet mode.
+
+- `#553 <https://github.com/pytest-dev/pytest-xdist/issues/553>`_: When using ``-n auto``, count the number of physical CPU cores instead of logical ones.
+
+
+Trivial Changes
+---------------
+
+- `#541 <https://github.com/pytest-dev/pytest-xdist/issues/541>`_: ``pytest-xdist`` now requires ``pytest>=6.0``.
+
+
 pytest-xdist 1.34.0 (2020-07-27)
 ================================
 

--- a/changelog/471.bugfix
+++ b/changelog/471.bugfix
@@ -1,1 +1,0 @@
-Fix issue with Rsync reporting in quiet mode.

--- a/changelog/504.feature.rst
+++ b/changelog/504.feature.rst
@@ -1,1 +1,0 @@
-New functions ``xdist.is_xdist_worker``, ``xdist.is_xdist_master``, ``xdist.get_xdist_worker_id``, to easily identify the current node.

--- a/changelog/541.removal.rst
+++ b/changelog/541.removal.rst
@@ -1,1 +1,0 @@
-Drop backward-compatibility "slave" aliases related to worker nodes.  We deliberately moved away from this terminology years ago, and it seems like the right time to finish the deprecation and removal process.

--- a/changelog/541.trivial.rst
+++ b/changelog/541.trivial.rst
@@ -1,1 +1,0 @@
-``pytest-xdist`` now requires ``pytest>=6.0``.

--- a/changelog/553.bugfix.rst
+++ b/changelog/553.bugfix.rst
@@ -1,1 +1,0 @@
-When using ``-n auto``, count the number of physical CPU cores instead of logical ones.

--- a/changelog/569.removal.rst
+++ b/changelog/569.removal.rst
@@ -1,1 +1,0 @@
-``pytest-xdist`` no longer supports Python 2.7.


### PR DESCRIPTION
The py38-windows build will fail due to https://github.com/pytest-dev/pytest/issues/7638, but it is not related to pytest-xdist and will be fixed in the next pytest release.