### PR TITLE
Propagate internal errors to the master node

### DIFF
--- a/changelog/608.feature.rst
+++ b/changelog/608.feature.rst
@@ -1,0 +1,1 @@
+Internal errors in workers are now propagated to the master node.

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -33,8 +33,10 @@ class WorkerInteractor:
         self.channel.send((name, kwargs))
 
     def pytest_internalerror(self, excrepr):
-        for line in str(excrepr).split("\n"):
+        formatted_error = str(excrepr)
+        for line in formatted_error.split("\n"):
             self.log("IERROR>", line)
+        interactor.sendevent("internal_error", formatted_error=formatted_error)
 
     def pytest_sessionstart(self, session):
         self.session = session

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -324,6 +324,8 @@ class WorkerController:
                 self.log("ignoring {}({})".format(eventname, kwargs))
             elif eventname == "workerready":
                 self.notify_inproc(eventname, node=self, **kwargs)
+            elif eventname == "internal_error":
+                self.notify_inproc(eventname, node=self, **kwargs)
             elif eventname == "workerfinished":
                 self._down = True
                 self.workeroutput = kwargs["workeroutput"]

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1138,6 +1138,18 @@ def test_internal_error_with_maxfail(testdir):
     assert "INTERNALERROR" not in result.stderr.str()
 
 
+def test_internal_errors_propagate_to_master(testdir):
+    testdir.makeconftest(
+        """
+        def pytest_collection_modifyitems():
+            raise RuntimeError("Some runtime error")
+        """
+    )
+    testdir.makepyfile("def test(): pass")
+    result = testdir.runpytest("-n1")
+    result.stdout.fnmatch_lines(["*RuntimeError: Some runtime error*"])
+
+
 class TestLoadScope:
     def test_by_module(self, testdir):
         test_file = """


### PR DESCRIPTION
This should help users diagnose internal errors in workers like exceptions from hooks or in pytest itself.

