### PR TITLE
prepare for Node.fspath deprecation

### DIFF
--- a/changelog/623.bugfix.rst
+++ b/changelog/623.bugfix.rst
@@ -1,0 +1,1 @@
+Gracefully handle the pending deprecation of Node.fspath by using config.rootpath for topdir.

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -93,9 +93,14 @@ class WorkerInteractor:
         )
 
     def pytest_collection_finish(self, session):
+        try:
+            topdir = str(self.config.rootpath)
+        except AttributeError:  # pytest <= 6.1.0
+            topdir = str(self.config.rootdir)
+
         self.sendevent(
             "collectionfinish",
-            topdir=str(session.fspath),
+            topdir=topdir,
             ids=[item.nodeid for item in session.items],
         )
 


### PR DESCRIPTION
calculate topdir based on config.rootpath/rootdir

addresses pytest-dev/pytest#8251

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
