### PR TITLE
prepare #592: replace master with controller where we can

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -285,7 +285,18 @@ Since version 2.0, the following functions are also available in the ``xdist`` m
         """
 
     def is_xdist_master(request_or_session) -> bool:
-        """Return `True` if this is the xdist master, `False` otherwise
+        """Return `True` if this is the xdist controller, `False` otherwise
+
+        Note: this method also returns `False` when distribution has not been
+        activated at all.
+
+        deprecated alias for is_xdist_controller
+
+        :param request_or_session: the `pytest` `request` or `session` object
+        """
+
+     def is_xdist_controller(request_or_session) -> bool:
+        """Return `True` if this is the xdist controller, `False` otherwise
 
         Note: this method also returns `False` when distribution has not been
         activated at all.
@@ -295,7 +306,7 @@ Since version 2.0, the following functions are also available in the ``xdist`` m
 
     def get_xdist_worker_id(request_or_session) -> str:
         """Return the id of the current worker ('gw0', 'gw1', etc) or 'master'
-        if running on the 'master' node.
+        if running on the controller node.
 
         If not distributing tests (for example passing `-n0` or not passing `-n` at all) also return 'master'.
 

--- a/changelog/592.trivial.rst
+++ b/changelog/592.trivial.rst
@@ -1,0 +1,1 @@
+Replace master with controller where ever possible.

--- a/src/xdist/__init__.py
+++ b/src/xdist/__init__.py
@@ -1,4 +1,15 @@
-from xdist.plugin import is_xdist_worker, is_xdist_master, get_xdist_worker_id
+from xdist.plugin import (
+    is_xdist_worker,
+    is_xdist_master,
+    get_xdist_worker_id,
+    is_xdist_controller,
+)
 from xdist._version import version as __version__
 
-__all__ = ["__version__", "is_xdist_worker", "is_xdist_master", "get_xdist_worker_id"]
+__all__ = [
+    "__version__",
+    "is_xdist_worker",
+    "is_xdist_master",
+    "is_xdist_controller",
+    "get_xdist_worker_id",
+]

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -87,7 +87,7 @@ class DSession:
         self._session = None
 
     def pytest_collection(self):
-        # prohibit collection of test items in master process
+        # prohibit collection of test items in controller process
         return True
 
     @pytest.mark.trylast
@@ -240,7 +240,7 @@ class DSession:
             return
         self.config.hook.pytest_xdist_node_collection_finished(node=node, ids=ids)
         # tell session which items were effectively collected otherwise
-        # the master node will finish the session with EXIT_NOTESTSCOLLECTED
+        # the controller node will finish the session with EXIT_NOTESTSCOLLECTED
         self._session.testscollected = len(ids)
         self.sched.add_node_collection(node, ids)
         if self.terminal:

--- a/src/xdist/newhooks.py
+++ b/src/xdist/newhooks.py
@@ -48,7 +48,7 @@ def pytest_testnodedown(node, error):
 
 
 def pytest_xdist_node_collection_finished(node, ids):
-    """called by the master node when a node finishes collecting.
+    """called by the controller node when a worker node finishes collecting.
     """
 
 

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -227,8 +227,8 @@ def is_xdist_worker(request_or_session) -> bool:
     return hasattr(request_or_session.config, "workerinput")
 
 
-def is_xdist_master(request_or_session) -> bool:
-    """Return `True` if this is the xdist master, `False` otherwise
+def is_xdist_controller(request_or_session) -> bool:
+    """Return `True` if this is the xdist controller, `False` otherwise
 
     Note: this method also returns `False` when distribution has not been
     activated at all.
@@ -241,9 +241,13 @@ def is_xdist_master(request_or_session) -> bool:
     )
 
 
+# ALIAS: todo, deprecate
+is_xdist_master = is_xdist_controller
+
+
 def get_xdist_worker_id(request_or_session) -> str:
     """Return the id of the current worker ('gw0', 'gw1', etc) or 'master'
-    if running on the 'master' node.
+    if running on the controller node.
 
     If not distributing tests (for example passing `-n0` or not passing `-n` at all)
     also return 'master'.
@@ -253,6 +257,7 @@ def get_xdist_worker_id(request_or_session) -> str:
     if hasattr(request_or_session.config, "workerinput"):
         return request_or_session.config.workerinput["workerid"]
     else:
+        # TODO: remove "master", ideally for a None
         return "master"
 
 
@@ -261,6 +266,7 @@ def worker_id(request):
     """Return the id of the current worker ('gw0', 'gw1', etc) or 'master'
     if running on the master node.
     """
+    # TODO: remove "master", ideally for a None
     return get_xdist_worker_id(request)
 
 

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -241,7 +241,7 @@ def is_xdist_controller(request_or_session) -> bool:
     )
 
 
-# ALIAS: todo, deprecate
+# ALIAS: TODO, deprecate (#592)
 is_xdist_master = is_xdist_controller
 
 

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -116,7 +116,7 @@ class WorkerInteractor:
         self.sendevent("testreport", data=data)
 
     def pytest_collectreport(self, report):
-        # send only reports that have not passed to master as optimization (#330)
+        # send only reports that have not passed to controller as optimization (#330)
         if not report.passed:
             data = self.config.hook.pytest_report_to_serializable(
                 config=self.config, report=report
@@ -139,7 +139,7 @@ def serialize_warning_message(warning_message):
         message_class_name = type(warning_message.message).__name__
         message_str = str(warning_message.message)
         # check now if we can serialize the warning arguments (#349)
-        # if not, we will just use the exception message on the master node
+        # if not, we will just use the exception message on the controller node
         try:
             dumps(warning_message.message.args)
         except DumpError:


### PR DESCRIPTION
Replace master with controller where ever we can

the helper `is_xdist_master` still needs a deprecation

the return value of the worker id finder needs a breaking change to remove the `master` value

addresses part of #592 