### PR TITLE
LoadScope scheduler: Sort scopes by number of tests to assign biggest scopes first

### DIFF
--- a/changelog/632.feature.rst
+++ b/changelog/632.feature.rst
@@ -1,0 +1,1 @@
+LoadScope scheduler: Sort scopes by number of tests to assign biggest scopes first.

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -349,10 +349,17 @@ class LoadScopeScheduling:
             return
 
         # Determine chunks of work (scopes)
+        unsorted_workqueue = OrderedDict()
         for nodeid in self.collection:
             scope = self._split_scope(nodeid)
-            work_unit = self.workqueue.setdefault(scope, default=OrderedDict())
+            work_unit = unsorted_workqueue.setdefault(scope, default=OrderedDict())
             work_unit[nodeid] = False
+
+        # Insert tests scopes into work queue ordered by number of tests
+        for scope, nodeids in sorted(
+            unsorted_workqueue.items(), key=lambda item: -len(item[1])
+        ):
+            self.workqueue[scope] = nodeids
 
         # Avoid having more workers than work
         extra_nodes = len(self.nodes) - len(self.workqueue)


### PR DESCRIPTION
In the real world, test scopes aren't equal: Some have just a few tests which take little time to run while others can have a large amount of tests taking longer to finish.
With the current implementation it can happen that the scheduler assigns a scope with a large amount of tests very late in the run, often we see a single worker still running tests of a large scope while all other workers are idle because all other scopes have finished running.

This PR inserts scopes into the workqueue sorted by the amount of tests. The idea is to begin testing with the biggest scopes so that small scopes can essentially be bin packed late in the run so that all workers finish processing roughly at the same time.

I am aware that the number of tests is not the best indicator for test runtime but it is better than random scope assignment.
We have developed a more sophisticated version sorting with timings from previous test runs but unfortunately it requires external tooling.