### PR TITLE
create new dist option 'loadgroup'

### DIFF
--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -7,6 +7,7 @@ from xdist.scheduler import (
     LoadScheduling,
     LoadScopeScheduling,
     LoadFileScheduling,
+    LoadGroupScheduling,
 )
 
 
@@ -98,6 +99,7 @@ class DSession:
             "load": LoadScheduling,
             "loadscope": LoadScopeScheduling,
             "loadfile": LoadFileScheduling,
+            "loadgroup": LoadGroupScheduling,
         }
         return schedulers[dist](config, log)
 

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -75,7 +75,7 @@ def pytest_addoption(parser):
         "--dist",
         metavar="distmode",
         action="store",
-        choices=["each", "load", "loadscope", "loadfile", "no"],
+        choices=["each", "load", "loadscope", "loadfile", "loadgroup", "no"],
         dest="dist",
         default="no",
         help=(
@@ -87,6 +87,8 @@ def pytest_addoption(parser):
             " the same scope to any available environment.\n\n"
             "loadfile: load balance by sending test grouped by file"
             " to any available environment.\n\n"
+            "loadgroup: load balance by sending any pending test or test group"
+            " to any available enviroment.\n\n"
             "(default) no: run tests inprocess, don't distribute."
         ),
     )
@@ -185,6 +187,12 @@ def pytest_configure(config):
             tr.showfspath = False
     if config.getoption("boxed"):
         config.option.forked = True
+
+    config_line = (
+        "group: specify group for tests should run in same session."
+        "in relation to one another. " + "Provided by pytest-xdist."
+    )
+    config.addinivalue_line('markers', config_line)
 
 
 @pytest.mark.tryfirst

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -92,6 +92,20 @@ class WorkerInteractor:
             "runtest_protocol_complete", item_index=self.item_index, duration=duration
         )
 
+    def pytest_collection_modifyitems(self, session, config, items):
+        # add the group name to nodeid as suffix if --dist=loadgroup
+        if config.getvalue("loadgroup"):
+            for item in items:
+                try:
+                    mark = item.get_closest_marker("group")
+                except AttributeError:
+                    mark = item.get_marker("group")
+
+                if mark:
+                    gname = mark.kwargs.get("name")
+                    if gname:
+                        item._nodeid  = "%s@%s" % (item.nodeid, gname)
+
     def pytest_collection_finish(self, session):
         try:
             topdir = str(self.config.rootpath)
@@ -206,6 +220,7 @@ def remote_initconfig(option_dict, args):
 
 
 def setup_config(config, basetemp):
+    config.option.loadgroup = True if config.getvalue("dist") == "loadgroup" else False
     config.option.looponfail = False
     config.option.usepdb = False
     config.option.dist = "no"

--- a/src/xdist/scheduler/__init__.py
+++ b/src/xdist/scheduler/__init__.py
@@ -2,3 +2,4 @@ from xdist.scheduler.each import EachScheduling  # noqa
 from xdist.scheduler.load import LoadScheduling  # noqa
 from xdist.scheduler.loadfile import LoadFileScheduling  # noqa
 from xdist.scheduler.loadscope import LoadScopeScheduling  # noqa
+from xdist.scheduler.loadgroup import LoadGroupScheduling # noqa

--- a/src/xdist/scheduler/loadgroup.py
+++ b/src/xdist/scheduler/loadgroup.py
@@ -1,0 +1,67 @@
+from .loadscope import LoadScopeScheduling
+from py.log import Producer
+
+
+class LoadGroupScheduling(LoadScopeScheduling):
+    """Implement load scheduling across nodes, but grouping test only has group mark.
+
+    This distributes the tests collected across all nodes so each test is run
+    just once.  All nodes collect and submit the list of tests and when all
+    collections are received it is verified they are identical collections.
+    Then the collection gets divided up in work units, grouped by group mark
+    (If there is no group mark, it is itself a group.), and those work units 
+    et submitted to nodes. Whenever a node finishes an item, it calls 
+    ``.mark_test_complete()`` which will trigger the scheduler to assign more 
+    work units if the number of pending tests for the node falls below a low-watermark.
+
+    When created, ``numnodes`` defines how many nodes are expected to submit a
+    collection. This is used to know when all nodes have finished collection.
+
+    This class behaves very much like LoadScopeScheduling, 
+    but with a itself or group(by marked) scope.
+    """
+
+    def __init__(self, config, log=None):
+        super().__init__(config, log)
+        if log is None:
+            self.log = Producer("loadgroupsched")
+        else:
+            self.log = log.loadgroupsched
+
+    def _split_scope(self, nodeid):
+        """Determine the scope (grouping) of a nodeid.
+
+        There are usually 3 cases for a nodeid::
+
+            example/loadsuite/test/test_beta.py::test_beta0
+            example/loadsuite/test/test_delta.py::Delta1::test_delta0
+            example/loadsuite/epsilon/__init__.py::epsilon.epsilon
+
+        #. Function in a test module.
+        #. Method of a class in a test module.
+        #. Doctest in a function in a package.
+
+        With loadgroup, two cases are added::
+
+            example/loadsuite/test/test_beta.py::test_beta0
+            example/loadsuite/test/test_delta.py::Delta1::test_delta0
+            example/loadsuite/epsilon/__init__.py::epsilon.epsilon
+            example/loadsuite/test/test_gamma.py::test_beta0@gname
+            example/loadsuite/test/test_delta.py::Gamma1::test_gamma0@gname
+
+        This function will group tests with the scope determined by splitting
+        the first ``@`` from the right. That is, test will be grouped in a
+        single work unit when they have same group name.
+         In the above example, scopes will be::
+
+            example/loadsuite/test/test_beta.py::test_beta0
+            example/loadsuite/test/test_delta.py::Delta1::test_delta0
+            example/loadsuite/epsilon/__init__.py::epsilon.epsilon
+            gname
+            gname
+        """
+        if nodeid.rfind("@") > nodeid.rfind("]"):
+            # check the index of ']' to avoid the case: parametrize mark value has '@'
+            return nodeid.split("@")[-1]
+        else:
+            return nodeid


### PR DESCRIPTION
### Intro
There are currently several options for distributing tests,
but there is still no suitable option for the following cases:

### Case 1
In this case, it is efficient to divide all tests into different sessions.
```python
@pytest.mark.parametrize('param', [A, B, C, D])
def test_something_heavy(param):
    do_something_heavy_test
```

### Case 2
In this case, it is efficient to run all tests in the same session.
```python
def test_something_light_1(heavy_fixture_cannot_filelock):
    do_something_light_test

def test_something_light_2(heavy_fixture_cannot_filelock):
    do_something_light_test

def test_something_light_3(heavy_fixture_cannot_filelock):
    do_something_light_test
```

### Limit
If you use the loadscope option, all tests in Case 1 are performed in same session,
If the load option is used, all tests of Case 2 may be performed in different sessions.

### Suggestion
Use the following group mark and specify the name through the parameter.
Then, tests with the same name are executed in the same session.
```python
@pytest.mark.group(name="same_session")
def test_something_light_1(heavy_fixture_cannot_filelock):
    do_something_light_test

@pytest.mark.group(name="same_session")
def test_something_light_2(heavy_fixture_cannot_filelock):
    do_something_light_test

@pytest.mark.group(name="same_session")
def test_something_light_3(heavy_fixture_cannot_filelock):
    do_something_light_test
```
