### PR TITLE
[HOTFIX] rename pytest's branch(master to main)

### DIFF
--- a/changelog/638.bugfix.rst
+++ b/changelog/638.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue caused by changing the branch name of the pytest repository.

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist=
 extras = testing
 deps =
   pytestlatest: pytest
-  pytestmaster: git+https://github.com/pytest-dev/pytest.git@master
+  pytestmaster: git+https://github.com/pytest-dev/pytest.git@main
 commands=
   pytest {posargs}
 


### PR DESCRIPTION
It seems that the name of the master branch has been changed to main in the pytest repository.
