### PR TITLE
Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,23 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     -   id: black
         args: [--safe, --quiet, --target-version, py35]
         language_version: python3.7
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: debug-statements
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.0
+    hooks:
     -   id: flake8
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.2
+    rev: v2.10.1
     hooks:
     -   id: pyupgrade
         args: [--py3-plus]

--- a/src/xdist/newhooks.py
+++ b/src/xdist/newhooks.py
@@ -48,8 +48,7 @@ def pytest_testnodedown(node, error):
 
 
 def pytest_xdist_node_collection_finished(node, ids):
-    """called by the controller node when a worker node finishes collecting.
-    """
+    """called by the controller node when a worker node finishes collecting."""
 
 
 @pytest.mark.firstresult

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -157,8 +157,7 @@ class NodeManager:
 
 
 class HostRSync(execnet.RSync):
-    """ RSyncer that filters out common files
-    """
+    """RSyncer that filters out common files"""
 
     def __init__(self, sourcedir, *args, **kwargs):
         self._synced = {}
@@ -303,12 +302,12 @@ class WorkerController:
         self.putevent((eventname, kwargs))
 
     def process_from_remote(self, eventcall):  # noqa too complex
-        """ this gets called for each object we receive from
-            the other side and if the channel closes.
+        """this gets called for each object we receive from
+        the other side and if the channel closes.
 
-            Note that channel callbacks run in the receiver
-            thread of execnet gateways - we need to
-            avoid raising exceptions or doing heavy work.
+        Note that channel callbacks run in the receiver
+        thread of execnet gateways - we need to
+        avoid raising exceptions or doing heavy work.
         """
         try:
             if eventcall == self.ENDMARK:

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -718,8 +718,7 @@ def test_issue_594_random_parametrize(testdir):
 
 
 def test_tmpdir_disabled(testdir):
-    """Test xdist doesn't break if internal tmpdir plugin is disabled (#22).
-    """
+    """Test xdist doesn't break if internal tmpdir plugin is disabled (#22)."""
     p1 = testdir.makepyfile(
         """
         def test_ok():
@@ -733,8 +732,7 @@ def test_tmpdir_disabled(testdir):
 
 @pytest.mark.parametrize("plugin", ["xdist.looponfail", "xdist.boxed"])
 def test_sub_plugins_disabled(testdir, plugin):
-    """Test that xdist doesn't break if we disable any of its sub-plugins. (#32)
-    """
+    """Test that xdist doesn't break if we disable any of its sub-plugins. (#32)"""
     p1 = testdir.makepyfile(
         """
         def test_ok():
@@ -1239,14 +1237,22 @@ class TestFileScope:
             "test_b.py::TestB", result.outlines
         )
 
-        assert test_a_workers_and_test_count in (
-            {"gw0": 10},
-            {"gw1": 0},
-        ) or test_a_workers_and_test_count in ({"gw0": 0}, {"gw1": 10})
-        assert test_b_workers_and_test_count in (
-            {"gw0": 10},
-            {"gw1": 0},
-        ) or test_b_workers_and_test_count in ({"gw0": 0}, {"gw1": 10})
+        assert (
+            test_a_workers_and_test_count
+            in (
+                {"gw0": 10},
+                {"gw1": 0},
+            )
+            or test_a_workers_and_test_count in ({"gw0": 0}, {"gw1": 10})
+        )
+        assert (
+            test_b_workers_and_test_count
+            in (
+                {"gw0": 10},
+                {"gw1": 0},
+            )
+            or test_b_workers_and_test_count in ({"gw0": 0}, {"gw1": 10})
+        )
 
     def test_by_class(self, testdir):
         testdir.makepyfile(
@@ -1271,14 +1277,22 @@ class TestFileScope:
             "test_a.py::TestB", result.outlines
         )
 
-        assert test_a_workers_and_test_count in (
-            {"gw0": 10},
-            {"gw1": 0},
-        ) or test_a_workers_and_test_count in ({"gw0": 0}, {"gw1": 10})
-        assert test_b_workers_and_test_count in (
-            {"gw0": 10},
-            {"gw1": 0},
-        ) or test_b_workers_and_test_count in ({"gw0": 0}, {"gw1": 10})
+        assert (
+            test_a_workers_and_test_count
+            in (
+                {"gw0": 10},
+                {"gw1": 0},
+            )
+            or test_a_workers_and_test_count in ({"gw0": 0}, {"gw1": 10})
+        )
+        assert (
+            test_b_workers_and_test_count
+            in (
+                {"gw0": 10},
+                {"gw1": 0},
+            )
+            or test_b_workers_and_test_count in ({"gw0": 0}, {"gw1": 10})
+        )
 
     def test_module_single_start(self, testdir):
         """Fix test suite never finishing in case all workers start with a single test (#277)."""

--- a/testing/test_newhooks.py
+++ b/testing/test_newhooks.py
@@ -46,8 +46,7 @@ class TestHooks:
         )
 
     def test_node_collection_finished(self, testdir):
-        """Test pytest_xdist_node_collection_finished hook (#8).
-        """
+        """Test pytest_xdist_node_collection_finished hook (#8)."""
         testdir.makeconftest(
             """
             def pytest_xdist_node_collection_finished(node, ids):

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -37,7 +37,9 @@ class WorkerSetup:
         self.testdir = testdir
         self.events = Queue()
 
-    def setup(self,):
+    def setup(
+        self,
+    ):
         self.testdir.chdir()
         # import os ; os.environ['EXECNET_DEBUG'] = "2"
         self.gateway = execnet.makegateway()


### PR DESCRIPTION
Use `pre-commit autoupdate` to upgrade, and follow the message from `pre-commit-hooks` to move to the official `flake8` hook.
