### PR TITLE
Add explicit 'logical' choice to --numprocesses flag

### DIFF
--- a/changelog/646.feature.rst
+++ b/changelog/646.feature.rst
@@ -1,0 +1,3 @@
+Add ``--numprocesses=logical`` flag, which automatically uses the number of logical CPUs available, instead of physical CPUs with ``auto``.
+
+This is very useful for test suites which are not CPU-bound.

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -37,7 +37,7 @@ def pytest_xdist_auto_num_workers(config):
 
 
 def parse_numprocesses(s):
-    if s == "auto" or s == "logical":
+    if s in ("auto", "logical"):
         return s
     elif s is not None:
         return int(s)
@@ -192,7 +192,7 @@ def pytest_configure(config):
 @pytest.mark.tryfirst
 def pytest_cmdline_main(config):
     usepdb = config.getoption("usepdb", False)  # a core option
-    if config.option.numprocesses == "auto" or config.option.numprocesses == "logical":
+    if config.option.numprocesses in ("auto", "logical"):
         if usepdb:
             config.option.numprocesses = 0
             config.option.dist = "no"

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -5,13 +5,14 @@ import py
 import pytest
 
 
-def pytest_xdist_auto_num_workers():
+def pytest_xdist_auto_num_workers(config):
     try:
         import psutil
     except ImportError:
         pass
     else:
-        count = psutil.cpu_count(logical=False) or psutil.cpu_count()
+        use_logical = config.option.numprocesses == "logical"
+        count = psutil.cpu_count(logical=use_logical) or psutil.cpu_count()
         if count:
             return count
     try:
@@ -36,8 +37,8 @@ def pytest_xdist_auto_num_workers():
 
 
 def parse_numprocesses(s):
-    if s == "auto":
-        return "auto"
+    if s == "auto" or s == "logical":
+        return s
     elif s is not None:
         return int(s)
 
@@ -51,9 +52,10 @@ def pytest_addoption(parser):
         metavar="numprocesses",
         action="store",
         type=parse_numprocesses,
-        help="shortcut for '--dist=load --tx=NUM*popen', "
-        "you can use 'auto' here for auto detection CPUs number on "
-        "host system and it will be 0 when used with --pdb",
+        help="Shortcut for '--dist=load --tx=NUM*popen'. With 'auto', attempt "
+        "to detect physical CPU count. With 'logical', detect logical CPU "
+        "count. If physical CPU count cannot be found, falls back to logical "
+        "count. This will be 0 when used with --pdb.",
     )
     group.addoption(
         "--maxprocesses",
@@ -190,7 +192,7 @@ def pytest_configure(config):
 @pytest.mark.tryfirst
 def pytest_cmdline_main(config):
     usepdb = config.getoption("usepdb", False)  # a core option
-    if config.option.numprocesses == "auto":
+    if config.option.numprocesses == "auto" or config.option.numprocesses == "logical":
         if usepdb:
             config.option.numprocesses = 0
             config.option.dist = "no"

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -69,6 +69,12 @@ def test_auto_detect_cpus(testdir, monkeypatch):
     assert config.getoption("numprocesses") == 0
     assert config.getoption("dist") == "no"
 
+    config = testdir.parseconfigure("-nlogical", "--pdb")
+    check_options(config)
+    assert config.getoption("usepdb")
+    assert config.getoption("numprocesses") == 0
+    assert config.getoption("dist") == "no"
+
     monkeypatch.delattr(os, "sched_getaffinity", raising=False)
     monkeypatch.setenv("TRAVIS", "true")
     config = testdir.parseconfigure("-nauto")
@@ -81,11 +87,15 @@ def test_auto_detect_cpus_psutil(testdir, monkeypatch):
 
     psutil = pytest.importorskip("psutil")
 
-    monkeypatch.setattr(psutil, "cpu_count", lambda logical=True: 42)
+    monkeypatch.setattr(psutil, "cpu_count", lambda logical=True: 84 if logical else 42)
 
     config = testdir.parseconfigure("-nauto")
     check_options(config)
     assert config.getoption("numprocesses") == 42
+
+    config = testdir.parseconfigure("-nlogical")
+    check_options(config)
+    assert config.getoption("numprocesses") == 84
 
 
 def test_hook_auto_num_workers(testdir, monkeypatch):
@@ -98,6 +108,10 @@ def test_hook_auto_num_workers(testdir, monkeypatch):
     """
     )
     config = testdir.parseconfigure("-nauto")
+    check_options(config)
+    assert config.getoption("numprocesses") == 42
+
+    config = testdir.parseconfigure("-nlogical")
     check_options(config)
     assert config.getoption("numprocesses") == 42
 


### PR DESCRIPTION
With the change to physical CPU count in #560, test sets that are run with `psutil` installed and that are not CPU-bound (in my case, with lots of network activity) take roughly twice as long to execute on hyperthreaded CPUs. Add a new choice `logical` for flag `--numprocesses` for use cases like this.

This implementation is a bit weird because of the multiple fallback paths in `pytest_xdist_auto_num_workers()` which all return the logical CPU count already, but I don't see a better option.

Testing:
- Ran `tox` against all but `python3.5` on Linux:
```
$ python3.9 -m tox -p
...
✔ OK linting in 5.201 seconds
✔ OK py38-psutil in 7.751 seconds
✔ OK py39-pytestlatest in 39.017 seconds
✔ OK py38-pytestlatest in 39.792 seconds
✔ OK py38-pytestmain in 42.884 seconds
✔ OK py36-pytestlatest in 48.754 seconds
__________________________ summary __________________________ 
  linting: commands succeeded
  py36-pytestlatest: commands succeeded
  py38-pytestlatest: commands succeeded
  py39-pytestlatest: commands succeeded
  py38-pytestmain: commands succeeded
  py38-psutil: commands succeeded
  congratulations :)
```
- Ran a set of tests against this change and saw 12 workers when run with `--numprocesses logical` on my six-core hyperthreaded CPU.