### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,19 +11,15 @@ jobs:
       fail-fast: false
       matrix:
         tox_env:
-          - "py35-pytestlatest"
           - "py36-pytestlatest"
           - "py37-pytestlatest"
           - "py38-pytestlatest"
           - "py39-pytestlatest"
           - "py38-pytestmain"
           - "py38-psutil"
-          - "linting"
 
         os: [ubuntu-latest, windows-latest]
         include:
-          - tox_env: "py35-pytestlatest"
-            python: "3.5"
           - tox_env: "py36-pytestlatest"
             python: "3.6"
           - tox_env: "py37-pytestlatest"
@@ -36,8 +32,6 @@ jobs:
             python: "3.8"
           - tox_env: "py38-psutil"
             python: "3.8"
-          - tox_env: "linting"
-            python: "3.7"
 
     steps:
     - uses: actions/checkout@v1
@@ -53,31 +47,13 @@ jobs:
       run: |
         tox -e ${{ matrix.tox_env }}
 
-  linting:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: "3.7"
-    - name: Install tox
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
-    - name: Linting
-      run: |
-        tox -e linting
-
   deploy:
 
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
 
     runs-on: ubuntu-latest
 
-    needs: [build, linting]
+    needs: build
 
     steps:
     - uses: actions/checkout@v1

--- a/README.rst
+++ b/README.rst
@@ -149,16 +149,16 @@ where executing a high-scope fixture exactly once is important.
 Running tests in a Python subprocess
 ------------------------------------
 
-To instantiate a python3.5 subprocess and send tests to it, you may type::
+To instantiate a python3.9 subprocess and send tests to it, you may type::
 
-    pytest -d --tx popen//python=python3.5
+    pytest -d --tx popen//python=python3.9
 
-This will start a subprocess which is run with the ``python3.5``
+This will start a subprocess which is run with the ``python3.9``
 Python interpreter, found in your system binary lookup path.
 
 If you prefix the --tx option value like this::
 
-    --tx 3*popen//python=python3.5
+    --tx 3*popen//python=python3.9
 
 then three subprocesses would be created and tests
 will be load-balanced across these three processes.
@@ -371,7 +371,7 @@ You can also add default environments like this:
 .. code-block:: ini
 
     [pytest]
-    addopts = --tx ssh=myhost//python=python3.5 --tx ssh=myhost//python=python3.6
+    addopts = --tx ssh=myhost//python=python3.9 --tx ssh=myhost//python=python3.6
 
 and then just type::
 

--- a/changelog/654.removal.rst
+++ b/changelog/654.removal.rst
@@ -1,0 +1,1 @@
+Python 3.5 is no longer supported.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "pytest11": ["xdist = xdist.plugin", "xdist.looponfail = xdist.looponfail"]
     },
     zip_safe=False,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=install_requires,
     setup_requires=["setuptools_scm"],
     classifiers=[
@@ -40,7 +40,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
   linting
-  py{35,36,37,38,39}-pytestlatest
+  py{36,37,38,39}-pytestlatest
   py38-pytestmain
   py38-psutil
 
@@ -20,14 +20,6 @@ extras =
 deps = pytest
 commands =
   pytest {posargs:-k psutil}
-
-[testenv:linting]
-skip_install = True
-usedevelop = True
-passenv = PRE_COMMIT_HOME
-deps =
-  pre-commit
-commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:release]
 changedir=


### PR DESCRIPTION
pytest no longer supports it, and our CI is broken because of it.

Also removed `linting` given we are using pre-commit.ci.

Thanks for submitting a PR, your contribution is really appreciated!

Should we run pyupgrade as well?