### PR TITLE
Use current run dir on session fixture suggestion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ Here is the code:
             return produce_expensive_data()
 
         # get the temp directory shared by all workers
-        root_tmp_dir = tmp_path_factory.getbasetemp().parent
+        root_tmp_dir = tmp_path_factory.getbasetemp()
 
         fn = root_tmp_dir / "data.json"
         with FileLock(str(fn) + ".lock"):


### PR DESCRIPTION
It seems the intent for the session fixture workaround was to create the data **once per test run**.

But it was actually creating a file in the parent dir, which would be shared with next test runs, possibly
providing stale data from a long time ago.

For example, `tmp_path_factory.getbasetemp().parent` gives me the
`/tmp/pytest-of-USERNAME/` dir, which contains sub dirs for each test run, like `pytest-90`, `pytest-91`,  etc.

If we want to mimic session fixtures behaviour across multiple workers, the file should be created inside
`pytest-90`, `pytest-91`, not their parent.

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [ ] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
**Should I still create a changelog entry for this? It does not seem relevant for such change.**