### PR TITLE
Use setproctitle if available to show state

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
           - "py39-pytestlatest"
           - "py38-pytestmain"
           - "py38-psutil"
+          - "py38-setproctitle"
 
         os: [ubuntu-latest, windows-latest]
         include:
@@ -31,6 +32,8 @@ jobs:
           - tox_env: "py38-pytestmain"
             python: "3.8"
           - tox_env: "py38-psutil"
+            python: "3.8"
+          - tox_env: "py38-setproctitle"
             python: "3.8"
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -317,6 +317,26 @@ Since version 2.0, the following functions are also available in the ``xdist`` m
         """
 
 
+Identifying workers from the system environment
+-----------------------------------------------
+
+*New in version UNRELEASED TBD FIXME*
+
+If the `setproctitle`_ package is installed, ``pytest-xdist`` will use it to
+update the process title (command line) on its workers to show their current
+state.  The titles used are ``[pytest-xdist running] file.py/node::id`` and
+``[pytest-xdist idle]``, visible in standard tools like ``ps`` and ``top`` on
+Linux, Mac OS X and BSD systems.  For Windows, please follow `setproctitle`_'s
+pointer regarding the Process Explorer tool.
+
+This is intended purely as an UX enhancement, e.g. to track down issues with
+long-running or CPU intensive tests.  Errors in changing the title are ignored
+silently.  Please try not to rely on the title format or title changes in
+external scripts.
+
+.. _`setproctitle`: https://pypi.org/project/setproctitle/
+
+
 Uniquely identifying the current test run
 -----------------------------------------
 

--- a/changelog/696.feature.rst
+++ b/changelog/696.feature.rst
@@ -1,0 +1,2 @@
+Use setproctitle() to indicate current worker state if correspondent package
+is available.  Absent package (or any errors) just continues unchanged.

--- a/changelog/696.feature.rst
+++ b/changelog/696.feature.rst
@@ -1,2 +1,3 @@
-Use setproctitle() to indicate current worker state if correspondent package
-is available.  Absent package (or any errors) just continues unchanged.
+On Linux, the process title now changes to indicate the current worker state (running/idle).
+
+Depends on the `setproctitle <https://pypi.org/project/setproctitle/>`__ package, which can be installed with ``pip install pytest-xdist[setproctitle]``.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,11 @@ setup(
     platforms=["linux", "osx", "win32"],
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    extras_require={"testing": ["filelock"], "psutil": ["psutil>=3.0"]},
+    extras_require={
+        "testing": ["filelock"],
+        "psutil": ["psutil>=3.0"],
+        "setproctitle": ["setproctitle"],
+    },
     entry_points={
         "pytest11": ["xdist = xdist.plugin", "xdist.looponfail = xdist.looponfail"]
     },

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=
   py{36,37,38,39}-pytestlatest
   py38-pytestmain
   py38-psutil
+  py38-setproctitle
 
 [testenv]
 extras = testing
@@ -20,6 +21,14 @@ extras =
 deps = pytest
 commands =
   pytest {posargs:-k psutil}
+
+[testenv:py38-setproctitle]
+extras =
+  testing
+  setproctitle
+deps = pytest
+commands =
+  pytest {posargs}
 
 [testenv:release]
 changedir=


### PR DESCRIPTION
setproctitle() changes the process name, particularly in top/ps output
on posix-y systems.  This is very useful to get some transparency on
what's going on, especially if a test starts taking a very long time or
straight up hangs.

This is strictly a "bonus goodie", if setproctitle is not available,
it's not used, and any errors are ignored silently.