### PR TITLE
Fix test_fixture_teardown_failure for pytest master

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -568,7 +568,7 @@ def test_fixture_teardown_failure(testdir):
             pass
     """
     )
-    result = testdir.runpytest_subprocess("--debug", p)  # , "-n1")
+    result = testdir.runpytest_subprocess(p, "-n1")
     result.stdout.fnmatch_lines(["*ValueError*42*", "*1 passed*1 error*"])
     assert result.ret
 


### PR DESCRIPTION
`--debug` now receives an optional file, so the way the test
was calling pytest made it seem like it was passing the python file
file as the debug file.
