### PR TITLE
Provide a hook for the nodes being torn down

### DIFF
--- a/changelog/702.feature.rst
+++ b/changelog/702.feature.rst
@@ -1,0 +1,1 @@
+Add ``pytest_xdist_teardownnodes`` hook that is run when the nodes are being torn down.

--- a/src/xdist/newhooks.py
+++ b/src/xdist/newhooks.py
@@ -51,6 +51,10 @@ def pytest_xdist_node_collection_finished(node, ids):
     """called by the controller node when a worker node finishes collecting."""
 
 
+def pytest_xdist_teardownnodes(config):
+    """Called before before tearing down the nodes."""
+
+
 @pytest.mark.firstresult
 def pytest_xdist_make_scheduler(config, log):
     """return a node scheduler implementation"""

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -76,6 +76,7 @@ class NodeManager:
         return node
 
     def teardown_nodes(self):
+        self.config.hook.pytest_xdist_teardownnodes(config=self.config)
         self.group.terminate(self.EXIT_TIMEOUT)
 
     def _getxspecs(self):

--- a/testing/test_workermanage.py
+++ b/testing/test_workermanage.py
@@ -71,6 +71,8 @@ class TestNodeManagerPopen:
         assert len(hm.group) == 2
         hm.teardown_nodes()
         assert not len(hm.group)
+        call = hookrecorder.popcall("pytest_xdist_teardownnodes")
+        assert call.config is not None
 
     def test_popens_rsync(self, config, mysetup, workercontroller):
         source = mysetup.source


### PR DESCRIPTION
# Rationale

I've started to measure and track the runtime of the tests in a test suite (Django with pytest-django) and have noticed that a couple of tests have their runtime skewed by a significant amount. The reason for this is that the migrations in pytest-django are implemented as a session fixture (https://github.com/pytest-dev/pytest-django/pull/12#issuecomment-6697367). I'm experimenting a bit with moving the migrations out of the session fixture and putting them in hooks instead. This works fine when running without xdist as pytest provides plenty of hooks to use for this purpose:

```python
def pytest_sessionstart(session: pytest.Session) -> None:
    keep_db = session.config.getvalue("keepdb")
    setup_db(keep_db)
    run_migrations()

def pytest_sessionfinish(session: pytest.Session) -> None:
    keep_db = session.config.getvalue("keepdb")
    teardown_db(keep_db)
```

I was trying to do a similar setup for when the tests are run with xdist, but there seems to be no counterpart to `pytest_xdist_setupnodes`. This PR introduces a new hook for this and the end goal is to use it like following:

```python
class XDistSetupPlugin:
    def pytest_xdist_setupnodes(self, config: pytest.Config, specs: Any) -> None:
        keep_db = config.getvalue("keepdb")
        setup_db(keep_db)
        run_migrations()

    def pytest_xdist_teardownnodes(self, config: pytest.Config) -> None:
        keep_db = config.getvalue("keepdb")
        teardown_db(keep_db)


class PytestSetupPlugin:
    def pytest_sessionstart(self, session: pytest.Session) -> None:
        keep_db = session.config.getvalue("keepdb")
        setup_db(keep_db)
        run_migrations()

    def pytest_sessionfinish(self, session: pytest.Session) -> None:
        keep_db = session.config.getvalue("keepdb")
        teardown_db(keep_db)


@pytest.hookimpl(trylast=True)
def pytest_configure(config: pytest.Config) -> None:
    config.pluginmanager.register(
        XDistSetupPlugin()
        if config.pluginmanager.hasplugin("xdist") and config.getvalue("n")
        else PytestSetupPlugin()
    )
```

Let me know what your thoughts are on this ✌️ 

# Checklist 

- [x] Make sure to include reasonable tests for your change if necessary

- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
