### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
           - "py37-pytestlatest"
           - "py38-pytestlatest"
           - "py39-pytestlatest"
+          - "py310-pytestlatest"
           - "py38-pytestmain"
           - "py38-psutil"
           - "py38-setproctitle"
@@ -29,6 +30,8 @@ jobs:
             python: "3.8"
           - tox_env: "py39-pytestlatest"
             python: "3.9"
+          - tox_env: "py310-pytestlatest"
+            python: "3.10-dev"
           - tox_env: "py38-pytestmain"
             python: "3.8"
           - tox_env: "py38-psutil"
@@ -37,9 +40,9 @@ jobs:
             python: "3.8"
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
     - name: Install tox
@@ -59,9 +62,9 @@ jobs:
     needs: build
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: "3.7"
     - name: Install wheel

--- a/changelog/704.feature
+++ b/changelog/704.feature
@@ -1,0 +1,1 @@
+Add support for Python 3.10.

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
   linting
-  py{36,37,38,39}-pytestlatest
+  py{36,37,38,39,310}-pytestlatest
   py38-pytestmain
   py38-psutil
   py38-setproctitle


### PR DESCRIPTION
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```

---

Python 3.10.0 final is due for release in October:

* https://www.python.org/dev/peps/pep-0619/

The final release candidate is now out and the Python release team has issued a call to action for community members:

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.10 compatibilities during this phase. As always, report any issues to the Python bug tracker.

https://discuss.python.org/t/python-3-10-0rc2-is-now-available/10496?u=hugovk

So let's also test and add support for 3.10.

