### PR TITLE
Modernize packaging, require pytest 6.2, prepare for pytest 7, other changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
     hooks:
     -   id: black
         args: [--safe, --quiet, --target-version, py35]
-        language_version: python3.7
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
@@ -29,4 +28,3 @@ repos:
         files: ^(CHANGELOG.rst|HOWTORELEASE.rst|README.rst|changelog/.*)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
-        language_version: python3.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,12 @@ repos:
         files: ^(CHANGELOG.rst|HOWTORELEASE.rst|README.rst|changelog/.*)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910-1
+    hooks:
+    -   id: mypy
+        files: ^(src/|testing/)
+        args: []
+        additional_dependencies:
+          - pytest>=6.2.0
+          - py>=1.10.0

--- a/changelog/719.trivial.rst
+++ b/changelog/719.trivial.rst
@@ -1,0 +1,1 @@
+Use up-to-date ``setup.cfg``/``pyproject.toml`` packaging setup.

--- a/changelog/720.trivial.rst
+++ b/changelog/720.trivial.rst
@@ -1,0 +1,1 @@
+Require pytest>=6.2.0.

--- a/changelog/721.trivial.rst
+++ b/changelog/721.trivial.rst
@@ -1,0 +1,1 @@
+Started using type annotations and mypy checking internally. The types are incomplete and not published.

--- a/changelog/722.feature.rst
+++ b/changelog/722.feature.rst
@@ -1,0 +1,1 @@
+Full compatibility with pytest 7 - no deprecation warnings or use of legacy features.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,15 @@
+[build-system]
+requires = [
+  # sync with setup.py until we discard non-pep-517/518
+  "setuptools>=45.0",
+  "setuptools-scm[toml]>=6.2.3",
+  "wheel",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/xdist/_version.py"
+
 [tool.towncrier]
 package = "xdist"
 filename = "CHANGELOG.rst"

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,3 +58,19 @@ setproctitle = setproctitle
 
 [flake8]
 max-line-length = 100
+
+[mypy]
+mypy_path = src
+# TODO: Enable this & fix errors.
+# check_untyped_defs = True
+disallow_any_generics = True
+ignore_missing_imports = True
+no_implicit_optional = True
+show_error_codes = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
+warn_unused_configs = True
+# TODO: Enable this & fix errors.
+# no_implicit_reexport = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ zip_safe = False
 python_requires = >=3.6
 install_requires =
     execnet>=1.1
-    pytest>=6.0.0
+    pytest>=6.2.0
     pytest-forked
 setup_requires = setuptools_scm>=6.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,6 @@ pytest11 =
 [options.extras_require]
 testing =
     filelock
-    pytest
 psutil = psutil>=3.0
 setproctitle = setproctitle
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     execnet>=1.1
     pytest>=6.0.0
     pytest-forked
-setup_requires = setuptools_scm
+setup_requires = setuptools_scm>=6.0
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,61 @@
 [metadata]
+name = pytest-xdist
+description = pytest xdist plugin for distributed testing and loop-on-failing modes
+long_description = file: README.rst
+license = MIT
+author = holger krekel and contributors
+author_email = pytest-dev@python.org,holger@merlinux.eu
+url = https://github.com/pytest-dev/pytest-xdist
+platforms =
+    linux
+    osx
+    win32
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Framework :: Pytest
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Operating System :: POSIX
+    Operating System :: Microsoft :: Windows
+    Operating System :: MacOS :: MacOS X
+    Topic :: Software Development :: Testing
+    Topic :: Software Development :: Quality Assurance
+    Topic :: Utilities
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 license_file = LICENSE
+
+[options]
+packages = find:
+package_dir = =src
+zip_safe = False
+python_requires = >=3.6
+install_requires =
+    execnet>=1.1
+    pytest>=6.0.0
+    pytest-forked
+setup_requires = setuptools_scm
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+pytest11 =
+    xdist = xdist.plugin
+    xdist.looponfail = xdist.looponfail
+
+[options.extras_require]
+testing =
+    filelock
+    pytest
+psutil = psutil>=3.0
+setproctitle = setproctitle
 
 [flake8]
 max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -1,53 +1,6 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-install_requires = ["execnet>=1.1", "pytest>=6.0.0", "pytest-forked"]
-
-
-with open("README.rst") as f:
-    long_description = f.read()
-
-setup(
-    name="pytest-xdist",
-    use_scm_version={"write_to": "src/xdist/_version.py"},
-    description="pytest xdist plugin for distributed testing and loop-on-failing modes",
-    long_description=long_description,
-    license="MIT",
-    author="holger krekel and contributors",
-    author_email="pytest-dev@python.org,holger@merlinux.eu",
-    url="https://github.com/pytest-dev/pytest-xdist",
-    platforms=["linux", "osx", "win32"],
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
-    extras_require={
-        "testing": ["filelock"],
-        "psutil": ["psutil>=3.0"],
-        "setproctitle": ["setproctitle"],
-    },
-    entry_points={
-        "pytest11": ["xdist = xdist.plugin", "xdist.looponfail = xdist.looponfail"]
-    },
-    zip_safe=False,
-    python_requires=">=3.6",
-    install_requires=install_requires,
-    setup_requires=["setuptools_scm"],
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Framework :: Pytest",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: POSIX",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: MacOS :: MacOS X",
-        "Topic :: Software Development :: Testing",
-        "Topic :: Software Development :: Quality Assurance",
-        "Topic :: Utilities",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-    ],
-)
+if __name__ == "__main__":
+    setup(
+        use_scm_version={"write_to": "src/xdist/_version.py"},
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 from setuptools import setup
 
 if __name__ == "__main__":
-    setup(
-        use_scm_version={"write_to": "src/xdist/_version.py"},
-    )
+    setup()

--- a/src/xdist/looponfail.py
+++ b/src/xdist/looponfail.py
@@ -38,7 +38,7 @@ def pytest_cmdline_main(config):
 
 def looponfail_main(config):
     remotecontrol = RemoteControl(config)
-    rootdirs = config.getini("looponfailroots")
+    rootdirs = [py.path.local(root) for root in config.getini("looponfailroots")]
     statrecorder = StatRecorder(rootdirs)
     try:
         while 1:

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -1,9 +1,13 @@
 import os
 import uuid
 import sys
+from pathlib import Path
 
 import py
 import pytest
+
+
+PYTEST_GTE_7 = hasattr(pytest, "version_tuple") and pytest.version_tuple >= (7, 0)  # type: ignore[attr-defined]
 
 _sys_path = list(sys.path)  # freeze a copy of sys.path at interpreter startup
 
@@ -147,18 +151,18 @@ def pytest_addoption(parser):
     parser.addini(
         "rsyncdirs",
         "list of (relative) paths to be rsynced for remote distributed testing.",
-        type="pathlist",
+        type="paths" if PYTEST_GTE_7 else "pathlist",
     )
     parser.addini(
         "rsyncignore",
         "list of (relative) glob-style paths to be ignored for rsyncing.",
-        type="pathlist",
+        type="paths" if PYTEST_GTE_7 else "pathlist",
     )
     parser.addini(
         "looponfailroots",
-        type="pathlist",
+        type="paths" if PYTEST_GTE_7 else "pathlist",
         help="directories to check for changes",
-        default=[py.path.local()],
+        default=[Path.cwd() if PYTEST_GTE_7 else py.path.local()],
     )
 
 

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -250,7 +250,7 @@ def is_xdist_controller(request_or_session) -> bool:
 is_xdist_master = is_xdist_controller
 
 
-def get_xdist_worker_id(request_or_session) -> str:
+def get_xdist_worker_id(request_or_session):
     """Return the id of the current worker ('gw0', 'gw1', etc) or 'master'
     if running on the controller node.
 

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -236,8 +236,8 @@ def setup_config(config, basetemp):
 
 
 if __name__ == "__channelexec__":
-    channel = channel  # noqa
-    workerinput, args, option_dict, change_sys_path = channel.receive()
+    channel = channel  # type: ignore[name-defined] # noqa: F821
+    workerinput, args, option_dict, change_sys_path = channel.receive()  # type: ignore[name-defined]
 
     if change_sys_path is None:
         importpath = os.getcwd()
@@ -260,7 +260,7 @@ if __name__ == "__channelexec__":
 
     setup_config(config, option_dict.get("basetemp"))
     config._parser.prog = os.path.basename(workerinput["mainargv"][0])
-    config.workerinput = workerinput
-    config.workeroutput = {}
-    interactor = WorkerInteractor(config, channel)
+    config.workerinput = workerinput  # type: ignore[attr-defined]
+    config.workeroutput = {}  # type: ignore[attr-defined]
+    interactor = WorkerInteractor(config, channel)  # type: ignore[name-defined]
     config.hook.pytest_cmdline_main(config=config)

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -423,9 +423,9 @@ def unserialize_warning_message(data):
 
     kwargs = {"message": message, "category": category}
     # access private _WARNING_DETAILS because the attributes vary between Python versions
-    for attr_name in warnings.WarningMessage._WARNING_DETAILS:
+    for attr_name in warnings.WarningMessage._WARNING_DETAILS:  # type: ignore[attr-defined]
         if attr_name in ("message", "category"):
             continue
         kwargs[attr_name] = data[attr_name]
 
-    return warnings.WarningMessage(**kwargs)
+    return warnings.WarningMessage(**kwargs)  # type: ignore[arg-type]

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -254,9 +254,9 @@ class WorkerController:
             args = make_reltoroot(self.nodemanager.roots, args)
         if spec.popen:
             name = "popen-%s" % self.gateway.id
-            if hasattr(self.config, "_tmpdirhandler"):
-                basetemp = self.config._tmpdirhandler.getbasetemp()
-                option_dict["basetemp"] = str(basetemp.join(name))
+            if hasattr(self.config, "_tmp_path_factory"):
+                basetemp = self.config._tmp_path_factory.getbasetemp()
+                option_dict["basetemp"] = str(basetemp / name)
         self.config.hook.pytest_configure_node(node=self)
 
         remote_module = self.config.hook.pytest_xdist_getremotemodule()

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -118,8 +118,8 @@ class NodeManager:
     def _getrsyncoptions(self):
         """Get options to be passed for rsync."""
         ignores = list(self.DEFAULT_IGNORES)
-        ignores += self.config.option.rsyncignore
-        ignores += self.config.getini("rsyncignore")
+        ignores += [str(path) for path in self.config.option.rsyncignore]
+        ignores += [str(path) for path in self.config.getini("rsyncignore")]
 
         return {
             "ignores": ignores,

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,12 +1,13 @@
-import py
-import pytest
 import execnet
+import pytest
+import shutil
+from typing import List
 
 pytest_plugins = "pytester"
 
 
 @pytest.fixture(autouse=True)
-def _divert_atexit(request, monkeypatch):
+def _divert_atexit(request, monkeypatch: pytest.MonkeyPatch):
     import atexit
 
     finalizers = []
@@ -23,7 +24,7 @@ def _divert_atexit(request, monkeypatch):
         func(*args, **kwargs)
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser) -> None:
     parser.addoption(
         "--gx",
         action="append",
@@ -33,28 +34,28 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
-def specssh(request):
+def specssh(request) -> str:
     return getspecssh(request.config)
 
 
 # configuration information for tests
-def getgspecs(config):
+def getgspecs(config) -> List[execnet.XSpec]:
     return [execnet.XSpec(spec) for spec in config.getvalueorskip("gspecs")]
 
 
-def getspecssh(config):
+def getspecssh(config) -> str:  # type: ignore[return]
     xspecs = getgspecs(config)
     for spec in xspecs:
         if spec.ssh:
-            if not py.path.local.sysfind("ssh"):
-                py.test.skip("command not found: ssh")
+            if not shutil.which("ssh"):
+                pytest.skip("command not found: ssh")
             return str(spec)
-    py.test.skip("need '--gx ssh=...'")
+    pytest.skip("need '--gx ssh=...'")
 
 
-def getsocketspec(config):
+def getsocketspec(config) -> execnet.XSpec:
     xspecs = getgspecs(config)
     for spec in xspecs:
         if spec.socket:
             return spec
-    py.test.skip("need '--gx socket=...'")
+    pytest.skip("need '--gx socket=...'")

--- a/testing/test_workermanage.py
+++ b/testing/test_workermanage.py
@@ -1,39 +1,42 @@
+import execnet
 import py
 import pytest
+import shutil
 import textwrap
-import execnet
-from _pytest.pytester import HookRecorder
-from xdist import workermanage, newhooks
+from pathlib import Path
+from xdist import workermanage
 from xdist.workermanage import HostRSync, NodeManager
 
 pytest_plugins = "pytester"
 
 
 @pytest.fixture
-def hookrecorder(request, config):
-    hookrecorder = HookRecorder(config.pluginmanager)
-    if hasattr(hookrecorder, "start_recording"):
-        hookrecorder.start_recording(newhooks)
-    request.addfinalizer(hookrecorder.finish_recording)
+def hookrecorder(request, config, pytester: pytest.Pytester):
+    hookrecorder = pytester.make_hook_recorder(config.pluginmanager)
     return hookrecorder
 
 
 @pytest.fixture
-def config(testdir):
-    return testdir.parseconfig()
+def config(pytester: pytest.Pytester):
+    return pytester.parseconfig()
 
 
 @pytest.fixture
-def mysetup(tmpdir):
-    class mysetup:
-        source = tmpdir.mkdir("source")
-        dest = tmpdir.mkdir("dest")
-
-    return mysetup()
+def source(tmp_path: Path) -> Path:
+    source = tmp_path / "source"
+    source.mkdir()
+    return source
 
 
 @pytest.fixture
-def workercontroller(monkeypatch):
+def dest(tmp_path: Path) -> Path:
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    return dest
+
+
+@pytest.fixture
+def workercontroller(monkeypatch: pytest.MonkeyPatch):
     class MockController:
         def __init__(self, *args):
             pass
@@ -46,18 +49,20 @@ def workercontroller(monkeypatch):
 
 
 class TestNodeManagerPopen:
-    def test_popen_no_default_chdir(self, config):
+    def test_popen_no_default_chdir(self, config) -> None:
         gm = NodeManager(config, ["popen"])
         assert gm.specs[0].chdir is None
 
-    def test_default_chdir(self, config):
+    def test_default_chdir(self, config) -> None:
         specs = ["ssh=noco", "socket=xyz"]
         for spec in NodeManager(config, specs).specs:
             assert spec.chdir == "pyexecnetcache"
         for spec in NodeManager(config, specs, defaultchdir="abc").specs:
             assert spec.chdir == "abc"
 
-    def test_popen_makegateway_events(self, config, hookrecorder, workercontroller):
+    def test_popen_makegateway_events(
+        self, config, hookrecorder, workercontroller
+    ) -> None:
         hm = NodeManager(config, ["popen"] * 2)
         hm.setup_nodes(None)
         call = hookrecorder.popcall("pytest_xdist_setupnodes")
@@ -72,15 +77,16 @@ class TestNodeManagerPopen:
         hm.teardown_nodes()
         assert not len(hm.group)
 
-    def test_popens_rsync(self, config, mysetup, workercontroller):
-        source = mysetup.source
+    def test_popens_rsync(
+        self, config, source: Path, dest: Path, workercontroller
+    ) -> None:
         hm = NodeManager(config, ["popen"] * 2)
         hm.setup_nodes(None)
         assert len(hm.group) == 2
         for gw in hm.group:
 
             class pseudoexec:
-                args = []
+                args = []  # type: ignore[var-annotated]
 
                 def __init__(self, *args):
                     self.args.extend(args)
@@ -97,30 +103,37 @@ class TestNodeManagerPopen:
         assert not len(hm.group)
         assert "sys.path.insert" in gw.remote_exec.args[0]
 
-    def test_rsync_popen_with_path(self, config, mysetup, workercontroller):
-        source, dest = mysetup.source, mysetup.dest
+    def test_rsync_popen_with_path(
+        self, config, source: Path, dest: Path, workercontroller
+    ) -> None:
         hm = NodeManager(config, ["popen//chdir=%s" % dest] * 1)
         hm.setup_nodes(None)
-        source.ensure("dir1", "dir2", "hello")
+        source.joinpath("dir1", "dir2").mkdir(parents=True)
+        source.joinpath("dir1", "dir2", "hello").touch()
         notifications = []
         for gw in hm.group:
             hm.rsync(gw, source, notify=lambda *args: notifications.append(args))
         assert len(notifications) == 1
         assert notifications[0] == ("rsyncrootready", hm.group["gw0"].spec, source)
         hm.teardown_nodes()
-        dest = dest.join(source.basename)
-        assert dest.join("dir1").check()
-        assert dest.join("dir1", "dir2").check()
-        assert dest.join("dir1", "dir2", "hello").check()
+        dest = dest.joinpath(source.name)
+        assert dest.joinpath("dir1").exists()
+        assert dest.joinpath("dir1", "dir2").exists()
+        assert dest.joinpath("dir1", "dir2", "hello").exists()
 
     def test_rsync_same_popen_twice(
-        self, config, mysetup, hookrecorder, workercontroller
-    ):
-        source, dest = mysetup.source, mysetup.dest
+        self,
+        config,
+        source: Path,
+        dest: Path,
+        hookrecorder,
+        workercontroller,
+    ) -> None:
         hm = NodeManager(config, ["popen//chdir=%s" % dest] * 2)
         hm.roots = []
         hm.setup_nodes(None)
-        source.ensure("dir1", "dir2", "hello")
+        source.joinpath("dir1", "dir2").mkdir(parents=True)
+        source.joinpath("dir1", "dir2", "hello").touch()
         gw = hm.group[0]
         hm.rsync(gw, source)
         call = hookrecorder.popcall("pytest_xdist_rsyncstart")
@@ -131,83 +144,98 @@ class TestNodeManagerPopen:
 
 
 class TestHRSync:
-    def test_hrsync_filter(self, mysetup):
-        source, _ = mysetup.source, mysetup.dest  # noqa
-        source.ensure("dir", "file.txt")
-        source.ensure(".svn", "entries")
-        source.ensure(".somedotfile", "moreentries")
-        source.ensure("somedir", "editfile~")
+    def test_hrsync_filter(self, source: Path, dest: Path) -> None:
+        source.joinpath("dir").mkdir()
+        source.joinpath("dir", "file.txt").touch()
+        source.joinpath(".svn").mkdir()
+        source.joinpath(".svn", "entries").touch()
+        source.joinpath(".somedotfile").mkdir()
+        source.joinpath(".somedotfile", "moreentries").touch()
+        source.joinpath("somedir").mkdir()
+        source.joinpath("somedir", "editfile~").touch()
         syncer = HostRSync(source, ignores=NodeManager.DEFAULT_IGNORES)
-        files = list(source.visit(rec=syncer.filter, fil=syncer.filter))
+        files = list(py.path.local(source).visit(rec=syncer.filter, fil=syncer.filter))
         assert len(files) == 3
         basenames = [x.basename for x in files]
         assert "dir" in basenames
         assert "file.txt" in basenames
         assert "somedir" in basenames
 
-    def test_hrsync_one_host(self, mysetup):
-        source, dest = mysetup.source, mysetup.dest
+    def test_hrsync_one_host(self, source: Path, dest: Path) -> None:
         gw = execnet.makegateway("popen//chdir=%s" % dest)
         finished = []
         rsync = HostRSync(source)
         rsync.add_target_host(gw, finished=lambda: finished.append(1))
-        source.join("hello.py").write("world")
+        source.joinpath("hello.py").write_text("world")
         rsync.send()
         gw.exit()
-        assert dest.join(source.basename, "hello.py").check()
+        assert dest.joinpath(source.name, "hello.py").exists()
         assert len(finished) == 1
 
 
 class TestNodeManager:
-    @py.test.mark.xfail(run=False)
-    def test_rsync_roots_no_roots(self, testdir, mysetup):
-        mysetup.source.ensure("dir1", "file1").write("hello")
-        config = testdir.parseconfig(mysetup.source)
-        nodemanager = NodeManager(config, ["popen//chdir=%s" % mysetup.dest])
+    @pytest.mark.xfail(run=False)
+    def test_rsync_roots_no_roots(
+        self, pytester: pytest.Pytester, source: Path, dest: Path
+    ) -> None:
+        source.joinpath("dir1").mkdir()
+        source.joinpath("dir1", "file1").write_text("hello")
+        config = pytester.parseconfig(source)
+        nodemanager = NodeManager(config, ["popen//chdir=%s" % dest])
         # assert nodemanager.config.topdir == source == config.topdir
-        nodemanager.makegateways()
-        nodemanager.rsync_roots()
-        (p,) = nodemanager.gwmanager.multi_exec(
+        nodemanager.makegateways()  # type: ignore[attr-defined]
+        nodemanager.rsync_roots()  # type: ignore[call-arg]
+        (p,) = nodemanager.gwmanager.multi_exec(  # type: ignore[attr-defined]
             "import os ; channel.send(os.getcwd())"
         ).receive_each()
-        p = py.path.local(p)
+        p = Path(p)
         print("remote curdir", p)
-        assert p == mysetup.dest.join(config.topdir.basename)
-        assert p.join("dir1").check()
-        assert p.join("dir1", "file1").check()
+        assert p == dest.joinpath(config.rootpath.name)
+        assert p.joinpath("dir1").check()
+        assert p.joinpath("dir1", "file1").check()
 
-    def test_popen_rsync_subdir(self, testdir, mysetup, workercontroller):
-        source, dest = mysetup.source, mysetup.dest
-        dir1 = mysetup.source.mkdir("dir1")
-        dir2 = dir1.mkdir("dir2")
-        dir2.ensure("hello")
+    def test_popen_rsync_subdir(
+        self, pytester: pytest.Pytester, source: Path, dest: Path, workercontroller
+    ) -> None:
+        dir1 = source / "dir1"
+        dir1.mkdir()
+        dir2 = dir1 / "dir2"
+        dir2.mkdir()
+        dir2.joinpath("hello").touch()
         for rsyncroot in (dir1, source):
-            dest.remove()
+            shutil.rmtree(str(dest), ignore_errors=True)
             nodemanager = NodeManager(
-                testdir.parseconfig(
+                pytester.parseconfig(
                     "--tx", "popen//chdir=%s" % dest, "--rsyncdir", rsyncroot, source
                 )
             )
             nodemanager.setup_nodes(None)  # calls .rsync_roots()
             if rsyncroot == source:
-                dest = dest.join("source")
-            assert dest.join("dir1").check()
-            assert dest.join("dir1", "dir2").check()
-            assert dest.join("dir1", "dir2", "hello").check()
+                dest = dest.joinpath("source")
+            assert dest.joinpath("dir1").exists()
+            assert dest.joinpath("dir1", "dir2").exists()
+            assert dest.joinpath("dir1", "dir2", "hello").exists()
             nodemanager.teardown_nodes()
 
     @pytest.mark.parametrize(
         "flag, expects_report", [("-q", False), ("", False), ("-v", True)]
     )
     def test_rsync_report(
-        self, testdir, mysetup, workercontroller, capsys, flag, expects_report
-    ):
-        source, dest = mysetup.source, mysetup.dest
-        dir1 = mysetup.source.mkdir("dir1")
-        args = "--tx", "popen//chdir=%s" % dest, "--rsyncdir", dir1, source
+        self,
+        pytester: pytest.Pytester,
+        source: Path,
+        dest: Path,
+        workercontroller,
+        capsys: pytest.CaptureFixture[str],
+        flag: str,
+        expects_report: bool,
+    ) -> None:
+        dir1 = source / "dir1"
+        dir1.mkdir()
+        args = ["--tx", "popen//chdir=%s" % dest, "--rsyncdir", str(dir1), str(source)]
         if flag:
-            args += (flag,)
-        nodemanager = NodeManager(testdir.parseconfig(*args))
+            args.append(flag)
+        nodemanager = NodeManager(pytester.parseconfig(*args))
         nodemanager.setup_nodes(None)  # calls .rsync_roots()
         out, _ = capsys.readouterr()
         if expects_report:
@@ -215,77 +243,86 @@ class TestNodeManager:
         else:
             assert "<= pytest/__init__.py" not in out
 
-    def test_init_rsync_roots(self, testdir, mysetup, workercontroller):
-        source, dest = mysetup.source, mysetup.dest
-        dir2 = source.ensure("dir1", "dir2", dir=1)
-        source.ensure("dir1", "somefile", dir=1)
-        dir2.ensure("hello")
-        source.ensure("bogusdir", "file")
-        source.join("tox.ini").write(
+    def test_init_rsync_roots(
+        self, pytester: pytest.Pytester, source: Path, dest: Path, workercontroller
+    ) -> None:
+        dir2 = source.joinpath("dir1", "dir2")
+        dir2.mkdir(parents=True)
+        source.joinpath("dir1", "somefile").mkdir()
+        dir2.joinpath("hello").touch()
+        source.joinpath("bogusdir").mkdir()
+        source.joinpath("bogusdir", "file").touch()
+        source.joinpath("tox.ini").write_text(
             textwrap.dedent(
                 """
-            [pytest]
-            rsyncdirs=dir1/dir2
-        """
+                [pytest]
+                rsyncdirs=dir1/dir2
+                """
             )
         )
-        config = testdir.parseconfig(source)
+        config = pytester.parseconfig(source)
         nodemanager = NodeManager(config, ["popen//chdir=%s" % dest])
         nodemanager.setup_nodes(None)  # calls .rsync_roots()
-        assert dest.join("dir2").check()
-        assert not dest.join("dir1").check()
-        assert not dest.join("bogus").check()
+        assert dest.joinpath("dir2").exists()
+        assert not dest.joinpath("dir1").exists()
+        assert not dest.joinpath("bogus").exists()
 
-    def test_rsyncignore(self, testdir, mysetup, workercontroller):
-        source, dest = mysetup.source, mysetup.dest
-        dir2 = source.ensure("dir1", "dir2", dir=1)
-        source.ensure("dir5", "dir6", "bogus")
-        source.ensure("dir5", "file")
-        dir2.ensure("hello")
-        source.ensure("foo", "bar")
-        source.ensure("bar", "foo")
-        source.join("tox.ini").write(
+    def test_rsyncignore(
+        self, pytester: pytest.Pytester, source: Path, dest: Path, workercontroller
+    ) -> None:
+        dir2 = source.joinpath("dir1", "dir2")
+        dir2.mkdir(parents=True)
+        source.joinpath("dir5", "dir6").mkdir(parents=True)
+        source.joinpath("dir5", "dir6", "bogus").touch()
+        source.joinpath("dir5", "file").touch()
+        dir2.joinpath("hello").touch()
+        source.joinpath("foo").mkdir()
+        source.joinpath("foo", "bar").touch()
+        source.joinpath("bar").mkdir()
+        source.joinpath("bar", "foo").touch()
+        source.joinpath("tox.ini").write_text(
             textwrap.dedent(
                 """
-            [pytest]
-            rsyncdirs = dir1 dir5
-            rsyncignore = dir1/dir2 dir5/dir6 foo*
-        """
+                [pytest]
+                rsyncdirs = dir1 dir5
+                rsyncignore = dir1/dir2 dir5/dir6 foo*
+                """
             )
         )
-        config = testdir.parseconfig(source)
+        config = pytester.parseconfig(source)
         config.option.rsyncignore = ["bar"]
         nodemanager = NodeManager(config, ["popen//chdir=%s" % dest])
         nodemanager.setup_nodes(None)  # calls .rsync_roots()
-        assert dest.join("dir1").check()
-        assert not dest.join("dir1", "dir2").check()
-        assert dest.join("dir5", "file").check()
-        assert not dest.join("dir6").check()
-        assert not dest.join("foo").check()
-        assert not dest.join("bar").check()
+        assert dest.joinpath("dir1").exists()
+        assert not dest.joinpath("dir1", "dir2").exists()
+        assert dest.joinpath("dir5", "file").exists()
+        assert not dest.joinpath("dir6").exists()
+        assert not dest.joinpath("foo").exists()
+        assert not dest.joinpath("bar").exists()
 
-    def test_optimise_popen(self, testdir, mysetup, workercontroller):
-        source = mysetup.source
+    def test_optimise_popen(
+        self, pytester: pytest.Pytester, source: Path, dest: Path, workercontroller
+    ) -> None:
         specs = ["popen"] * 3
-        source.join("conftest.py").write("rsyncdirs = ['a']")
-        source.ensure("a", dir=1)
-        config = testdir.parseconfig(source)
+        source.joinpath("conftest.py").write_text("rsyncdirs = ['a']")
+        source.joinpath("a").mkdir()
+        config = pytester.parseconfig(source)
         nodemanager = NodeManager(config, specs)
         nodemanager.setup_nodes(None)  # calls .rysnc_roots()
         for gwspec in nodemanager.specs:
             assert gwspec._samefilesystem()
             assert not gwspec.chdir
 
-    def test_ssh_setup_nodes(self, specssh, testdir):
-        testdir.makepyfile(
+    def test_ssh_setup_nodes(self, specssh: str, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile(
             __init__="",
             test_x="""
             def test_one():
                 pass
         """,
         )
-        reprec = testdir.inline_run(
-            "-d", "--rsyncdir=%s" % testdir.tmpdir, "--tx", specssh, testdir.tmpdir
+        reprec = pytester.inline_run(
+            "-d", "--rsyncdir=%s" % pytester.path, "--tx", specssh, pytester.path
         )
         (rep,) = reprec.getreports("pytest_runtest_logreport")
         assert rep.passed

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,14 @@ deps = pytest
 commands =
   pytest {posargs}
 
+[testenv:linting]
+skip_install = True
+usedevelop = True
+passenv = PRE_COMMIT_HOME
+deps =
+  pre-commit
+commands = pre-commit run --all-files --show-diff-on-failure
+
 [testenv:release]
 changedir=
 decription = do a release, required posarg of the version number

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ commands=
 extras =
   testing
   psutil
-deps = pytest
 commands =
   pytest {posargs:-k psutil}
 


### PR DESCRIPTION
Before we release pytest 7 I figured that pytest-xdist should be ready for it.

Please see the commits for all of the changes. I can break it down to multiple PRs if preferred.