### PR TITLE
Deprecate `--boxed`

### DIFF
--- a/changelog/468.deprecation.rst
+++ b/changelog/468.deprecation.rst
@@ -1,0 +1,3 @@
+The ``--boxed`` commmand line argument is deprecated.
+Install pytest-forked and use ``--forked`` instead.
+pytest-xdist 3.0.0 will remove the ``--boxed`` argument and pytest-forked dependency.

--- a/example/boxed.txt
+++ b/example/boxed.txt
@@ -1,9 +1,9 @@
-.. note::
+.. warning::
 
   Since 1.19.0, the actual implementation of the ``--boxed`` option has been moved to a
   separate plugin, `pytest-forked <https://github.com/pytest-dev/pytest-forked>`_
-  which can be installed independently. The ``--boxed`` command-line options remains
-  for backward compatibility reasons.
+  which can be installed independently. The ``--boxed`` command-line option is deprecated
+  and will be removed in pytest-xdist 3.0.0; use ``--forked`` from pytest-forked instead.
 
 
 If your testing involves C or C++ libraries you might have to deal

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -193,6 +193,12 @@ def pytest_configure(config):
         if tr:
             tr.showfspath = False
     if config.getoption("boxed"):
+        warning = DeprecationWarning(
+            "The --boxed commmand line argument is deprecated. "
+            "Install pytest-forked and use --forked instead. "
+            "pytest-xdist 3.0.0 will remove the --boxed argument and pytest-forked dependency."
+        )
+        config.issue_config_time_warning(warning, 2)
         config.option.forked = True
 
 

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -738,7 +738,7 @@ def test_tmpdir_disabled(pytester: pytest.Pytester) -> None:
     result.stdout.fnmatch_lines("*1 passed*")
 
 
-@pytest.mark.parametrize("plugin", ["xdist.looponfail", "xdist.boxed"])
+@pytest.mark.parametrize("plugin", ["xdist.looponfail"])
 def test_sub_plugins_disabled(pytester, plugin) -> None:
     """Test that xdist doesn't break if we disable any of its sub-plugins. (#32)"""
     p1 = pytester.makepyfile(


### PR DESCRIPTION
This will allow removing the pytest-forked dependency in the future.

Refs #468.