### PR TITLE
Fix test_warning_captured_deprecated_in_pytest_6

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -790,7 +790,7 @@ class TestWarnings:
                 warnings.warn("my custom worker warning")
         """
         )
-        result = pytester.runpytest("-n1")
+        result = pytester.runpytest("-n1", "-Wignore")
         result.stdout.fnmatch_lines(["*1 passed*"])
         result.stdout.no_fnmatch_line("*this hook should not be called in this version")
 


### PR DESCRIPTION
This test started to fail in the 'py38-pytestmain' environment, the cause being `PytestRemovedIn7Warning` being raised by the `conftest.py` file of the test itself. Ignoring it is fine, the purpose of the test is to ensure the hook is not called by `pytest-xdist`.

