### PR TITLE
correct setuptools_scm support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     execnet>=1.1
     pytest>=6.2.0
     pytest-forked
-setup_requires = setuptools_scm>=6.0
+setup_requires = # left empty, enforce using isolated build system
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=
   py38-pytestmain
   py38-psutil
   py38-setproctitle
-
+isolated_build = true
 [testenv]
 extras = testing
 deps =


### PR DESCRIPTION
modern setuptools_scm drops python 3.6

* use build isolation
* drop setup_requires

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [ ] Make sure to include reasonable tests for your change if necessary

- [ ] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
