### PR TITLE
remove py._pydir as rsync candidate

### DIFF
--- a/changelog/823.trivial.rst
+++ b/changelog/823.trivial.rst
@@ -1,0 +1,1 @@
+Remove usage of ``py._pydir`` as an rsync candidate.

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -101,7 +101,7 @@ class NodeManager:
         pytestpath = get_dir(pytest.__file__)
         pytestdir = get_dir(_pytest.__file__)
         config = self.config
-        candidates = [py._pydir, pytestpath, pytestdir]
+        candidates = [pytestpath, pytestdir]
         candidates += config.option.rsyncdir
         rsyncroots = config.getini("rsyncdirs")
         if rsyncroots:


### PR DESCRIPTION
afaict this shouldn't matter since this only supports `pytest` now (and that root is included)