### PR TITLE
Get `-nauto` default from `PYTEST_XDIST_AUTO_NUM_WORKERS`

### DIFF
--- a/changelog/792.feature
+++ b/changelog/792.feature
@@ -1,0 +1,2 @@
+The environment variable ``PYTEST_XDIST_AUTO_NUM_WORKERS`` can now be used to
+specify the default for ``-n auto`` and ``-n logical``.

--- a/changelog/829.doc
+++ b/changelog/829.doc
@@ -1,0 +1,1 @@
+Document the ``-n logical`` option.

--- a/docs/distribution.rst
+++ b/docs/distribution.rst
@@ -12,13 +12,29 @@ noticeable amount of time.
 
 With ``-n auto``, pytest-xdist will use as many processes as your computer
 has CPU cores.
+
+Use ``-n logical`` to use the number of *logical* CPU cores rather than
+physical ones. This currently requires the ``psutils`` package to be installed;
+if it is not, pytest-xdist will fall back to ``-n auto`` behavior.
+
 Pass a number, e.g. ``-n 8``, to specify the number of processes explicitly.
 
-To specify a different meaning for ``-n auto`` for your tests,
-you can implement the ``pytest_xdist_auto_num_workers``
-`pytest hook <https://docs.pytest.org/en/latest/how-to/writing_plugins.html>`__
-(a function named ``pytest_xdist_auto_num_workers`` in e.g. ``conftest.py``)
-that returns the number of processes to use.
+To specify a different meaning for ``-n auto`` and ``-n logical`` for your
+tests, you can:
+
+* Set the environment variable ``PYTEST_XDIST_AUTO_NUM_WORKERS`` to the
+  desired number of processes.
+
+* Implement the ``pytest_xdist_auto_num_workers``
+  `pytest hook <https://docs.pytest.org/en/latest/how-to/writing_plugins.html>`__
+  (a ``pytest_xdist_auto_num_workers(config)`` function in e.g. ``conftest.py``)
+  that returns the number of processes to use.
+  The hook can use ``config.option.numprocesses`` to determine if the user
+  asked for ``"auto"`` or ``"logical"``, and it can return ``None`` to fall
+  back to the default.
+
+If both the hook and environment variable are specified, the hook takes
+priority.
 
 
 Parallelization can be configured further with these options:

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 import sys
+import warnings
 
 import pytest
 
@@ -12,6 +13,13 @@ _sys_path = list(sys.path)  # freeze a copy of sys.path at interpreter startup
 
 @pytest.hookimpl
 def pytest_xdist_auto_num_workers(config):
+    env_var = os.environ.get("PYTEST_XDIST_AUTO_NUM_WORKERS")
+    if env_var:
+        try:
+            return int(env_var)
+        except ValueError:
+            warnings.warn("PYTEST_XDIST_AUTO_NUM_WORKERS is not a number. Ignoring it.")
+
     try:
         import psutil
     except ImportError:

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -18,7 +18,7 @@ def pytest_xdist_auto_num_workers(config):
         try:
             return int(env_var)
         except ValueError:
-            warnings.warn("PYTEST_XDIST_AUTO_NUM_WORKERS is not a number. Ignoring it.")
+            warnings.warn("PYTEST_XDIST_AUTO_NUM_WORKERS is not a number: {env_var!r}. Ignoring it.")
 
     try:
         import psutil


### PR DESCRIPTION
A few additional tests for existing functionality are added too.
And the ``-n logical`` option is documented.

Fixes: https://github.com/pytest-dev/pytest-xdist/issues/792
