### PR TITLE
fix and update packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,12 +70,12 @@ jobs:
     - name: Install wheel
       run: |
         python -m pip install --upgrade pip
-        pip install wheel
+        pip install build
     - name: Build package
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_token }}

--- a/changelog/812.feature
+++ b/changelog/812.feature
@@ -19,4 +19,3 @@ the fixture, the fixture was created only once.
 So restore the old behavior for typical cases where the number of tests is
 much greater than the number of workers (or, strictly speaking, when there
 are at least 2 tests for every node).
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
-  # sync with setup.py until we discard non-pep-517/518
   "setuptools>=45.0",
   "setuptools-scm[toml]>=6.2.3",
   "wheel",

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ python_requires = >=3.6
 install_requires =
     execnet>=1.1
     pytest>=6.2.0
-setup_requires = # left empty, enforce using isolated build system
 
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-from setuptools import setup
-
-if __name__ == "__main__":
-    setup()

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -18,7 +18,9 @@ def pytest_xdist_auto_num_workers(config):
         try:
             return int(env_var)
         except ValueError:
-            warnings.warn("PYTEST_XDIST_AUTO_NUM_WORKERS is not a number: {env_var!r}. Ignoring it.")
+            warnings.warn(
+                "PYTEST_XDIST_AUTO_NUM_WORKERS is not a number: {env_var!r}. Ignoring it."
+            )
 
     try:
         import psutil

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -28,8 +28,8 @@ class Producer:
     """
     Simplified implementation of the same interface as py.log, for backward compatibility
     since we dropped the dependency on pylib.
-    Note: this is defined here because this module can't depend on xdist, so we need 
-    to have the other way around.    
+    Note: this is defined here because this module can't depend on xdist, so we need
+    to have the other way around.
     """
 
     def __init__(self, name: str, *, enabled: bool = True):

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -12,7 +12,8 @@ import pytest
 @pytest.fixture
 def monkeypatch_3_cpus(monkeypatch: pytest.MonkeyPatch):
     """Make pytest-xdist believe the system has 3 CPUs"""
-    monkeypatch.setitem(sys.modules, "psutil", None)  # block import
+    # block import
+    monkeypatch.setitem(sys.modules, "psutil", None)  # type: ignore
     monkeypatch.delattr(os, "sched_getaffinity", raising=False)
     monkeypatch.setattr(os, "cpu_count", lambda: 3)
 


### PR DESCRIPTION
* drop empty setup.py which "breaks" on incomplete build envs
* use the build package to build the dist
* update the gh workflow to use it

fixup noise from pre-commit

addresses the artifact building issues seen in #830 

left without changelog data to ensure easy merge into the release branch for @nicoddemus later