### PR TITLE
Remove deprecated stuff from the package description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytest-xdist
-description = pytest xdist plugin for distributed testing and loop-on-failing modes
+description = pytest xdist plugin for distributed testing, most importantly across multiple CPUs
 long_description = file: README.rst
 license = MIT
 author = holger krekel and contributors


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest-xdist/issues/835