### PR TITLE
Tests: Unset PYTEST_XDIST_AUTO_NUM_WORKERS when the behavior without the envvar is asserted

### DIFF
--- a/changelog/870.trivial
+++ b/changelog/870.trivial
@@ -1,0 +1,1 @@
+Make the tests pass even when ``$PYTEST_XDIST_AUTO_NUM_WORKERS`` is set.

--- a/testing/test_plugin.py
+++ b/testing/test_plugin.py
@@ -54,6 +54,8 @@ def test_auto_detect_cpus(
 ) -> None:
     from xdist.plugin import pytest_cmdline_main as check_options
 
+    monkeypatch.delenv("PYTEST_XDIST_AUTO_NUM_WORKERS", raising=False)
+
     with suppress(ImportError):
         import psutil
 
@@ -101,6 +103,7 @@ def test_auto_detect_cpus_psutil(
 
     psutil = pytest.importorskip("psutil")
 
+    monkeypatch.delenv("PYTEST_XDIST_AUTO_NUM_WORKERS", raising=False)
     monkeypatch.setattr(psutil, "cpu_count", lambda logical=True: 84 if logical else 42)
 
     config = pytester.parseconfigure("-nauto")
@@ -116,6 +119,8 @@ def test_auto_detect_cpus_os(
     pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch, monkeypatch_3_cpus
 ) -> None:
     from xdist.plugin import pytest_cmdline_main as check_options
+
+    monkeypatch.delenv("PYTEST_XDIST_AUTO_NUM_WORKERS", raising=False)
 
     config = pytester.parseconfigure("-nauto")
     check_options(config)
@@ -177,6 +182,8 @@ def test_hook_auto_num_workers_none(
     # Returning None from a hook to skip it is pytest behavior,
     # but we document it so let's test it.
     from xdist.plugin import pytest_cmdline_main as check_options
+
+    monkeypatch.delenv("PYTEST_XDIST_AUTO_NUM_WORKERS", raising=False)
 
     pytester.makeconftest(
         """


### PR DESCRIPTION

- [x] Make sure to include reasonable tests for your change if necessary

- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
