### PR TITLE
docs: Remove unused statement in one-log-per-worker example

### DIFF
--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -221,7 +221,6 @@ Example:
     def pytest_configure(config):
         worker_id = os.environ.get("PYTEST_XDIST_WORKER")
         if worker_id is not None:
-            log_file = config.getini("worker_log_file")
             logging.basicConfig(
                 format=config.getini("log_file_format"),
                 filename=f"tests_{worker_id}.log",


### PR DESCRIPTION
- [x] Make sure to include reasonable tests for your change if necessary
  - Not necessary
- [x] Please add a *news* file into the `changelog` folder following these guidelines
  - Not necessary, just a docs change