### PR TITLE
Fix hang caused by `steal` command with empty test queue

### DIFF
--- a/changelog/884.bugfix
+++ b/changelog/884.bugfix
@@ -1,0 +1,1 @@
+Fixed hang in ``worksteal`` scheduler.


### PR DESCRIPTION
Fixes #884