### PR TITLE
Release 3.3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ on:
     branches:
       - "*"
 
+# Cancel running jobs for the same workflow and branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   check-package:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,14 @@ on:
       - "*"
 
 jobs:
+
+  check-package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build and Check Package
+      uses: hynek/build-and-inspect-python-package@v1.5
+
   test:
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,8 @@ name: test
 on:
   push:
     branches:
-      - "*"
+      - master
+      - "test-me-*"
 
   pull_request:
     branches:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+pytest-xdist 3.3.0 (2023-05-12)
+===============================
+
+Features
+--------
+
+- `#555 <https://github.com/pytest-dev/pytest-xdist/issues/555>`_: Improved progress output when collecting nodes to be less verbose.
+
+
 pytest-xdist 3.2.1 (2023-03-12)
 ===============================
 

--- a/changelog/555.improvement.rst
+++ b/changelog/555.improvement.rst
@@ -1,1 +1,0 @@
-Improved progress output when collecting nodes to be less verbose.

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 name = pytest-xdist
 description = pytest xdist plugin for distributed testing, most importantly across multiple CPUs
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 license = MIT
 author = holger krekel and contributors
 author_email = pytest-dev@python.org,holger@merlinux.eu


### PR DESCRIPTION
We will also use this opportunity to test the new deploy workflow. 👍 

(Note that now release branches *must* be pushed to the main repository, no longer to the forks).