### PR TITLE
Avoid unnecessary rinfo calls after creating gateways

### DIFF
--- a/changelog/907.bugfix.rst
+++ b/changelog/907.bugfix.rst
@@ -1,2 +1,4 @@
-Avoid unnecessary remote calls during node startup, which might trigger a bug in execnet that causes
-tests to execute in threads other than the main thread.
+Avoid remote calls during startup as execnet by default does not ensure remote affinity with the main thread and accidentially sheduling the pytest worker into a non main thread breaks numerous frameworks.
+For example asyncio, anyio, pyqt/pyside.
+
+A more safe correction will require thread affinity in execnet.

--- a/changelog/907.bugfix.rst
+++ b/changelog/907.bugfix.rst
@@ -1,0 +1,2 @@
+Avoid unnecessary remote calls during node startup, which might trigger a bug in execnet that causes
+tests to execute in threads other than the main thread.

--- a/changelog/907.bugfix.rst
+++ b/changelog/907.bugfix.rst
@@ -1,4 +1,5 @@
-Avoid remote calls during startup as execnet by default does not ensure remote affinity with the main thread and accidentially sheduling the pytest worker into a non main thread breaks numerous frameworks.
-For example asyncio, anyio, pyqt/pyside.
+Avoid remote calls during startup as ``execnet`` by default does not ensure remote affinity with the
+main thread and might accidentally schedule the pytest worker into a non-main thread, which breaks numerous frameworks,
+for example ``asyncio``, ``anyio``, ``PyQt/PySide``, etc.
 
-A more safe correction will require thread affinity in execnet.
+A more safe correction will require thread affinity in ``execnet`` (`pytest-dev/execnet#96 <https://github.com/pytest-dev/execnet/issues/96>`__).


### PR DESCRIPTION
Hopefully this fixes #907, as seems this is the only change in #901 which is somehow related.
