### PR TITLE
Docs: fix typo `index` -> `instead`

### DIFF
--- a/docs/how-it-works.rst
+++ b/docs/how-it-works.rst
@@ -29,8 +29,8 @@ The execution flow is:
    corresponds to the position of that test in the original collection
    list. This works because all nodes have the same collection list, and
    saves bandwidth because the **controller** can now tell one of the
-   workers to just *execute test index 3* index of passing the full test
-   id.
+   workers to just *execute test index 3* instead of passing the full
+   test id.
 
 4. If **dist-mode** is **each**: the **controller** just sends the full
    list of test indexes to each node at this moment.


### PR DESCRIPTION
Fix typo in `how-it-works.rst`: `index` -> `instead`

---

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary
    - Not necessary, small typo fix
- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
    - Not necessary, small typo fix
