### PR TITLE
Remove socketserver.py related section from the docs

### DIFF
--- a/docs/remote.rst
+++ b/docs/remote.rst
@@ -66,5 +66,3 @@ at once. The specifications strings use the `xspec syntax`_.
 .. _`xspec syntax`: https://codespeak.net/execnet/basics.html#xspec
 
 .. _`execnet`: https://codespeak.net/execnet
-
-.. _`socketserver.py`: https://raw.githubusercontent.com/pytest-dev/execnet/master/execnet/script/socketserver.py

--- a/docs/remote.rst
+++ b/docs/remote.rst
@@ -51,22 +51,6 @@ Those you cannot override using rsyncignore command-line or
 ini-file option(s).
 
 
-Sending tests to remote Socket Servers
---------------------------------------
-
-Download the single-module `socketserver.py`_ Python program
-and run it like this::
-
-    python socketserver.py
-
-It will tell you that it starts listening on the default
-port.  You can now on your home machine specify this
-new socket host with something like this::
-
-    pytest -d --tx socket=192.168.1.102:8888 --rsyncdir mypkg
-
-
-
 Running tests on many platforms at once
 ---------------------------------------
 


### PR DESCRIPTION
Given the script has been deleted, let us remove it from the docs as well to avoid confusion.

Fix #1001

