### PR TITLE
Use execnet main_thread_only execmodel

### DIFF
--- a/changelog/1027.improvement.rst
+++ b/changelog/1027.improvement.rst
@@ -1,0 +1,3 @@
+``pytest-xdist`` workers now always execute the tests in the main thread.
+
+Previously some tests might end up executing in a separate thread other than ``main`` in the workers, due to some internal `èxecnet`` details. This can cause problems specially with async frameworks where the event loop is running in the ``main`` thread (for example `#620 <https://github.com/pytest-dev/pytest-xdist/issues/620>`__).

--- a/changelog/620.bugfix
+++ b/changelog/620.bugfix
@@ -1,0 +1,1 @@
+Use the ``execnet`` new ``main_thread_only`` "execmodel" so that code which expects to only run in the main thread will now work as expected.

--- a/src/xdist/looponfail.py
+++ b/src/xdist/looponfail.py
@@ -82,7 +82,7 @@ class RemoteControl:
             print("RemoteControl:", msg)
 
     def initgateway(self) -> execnet.Gateway:
-        return execnet.makegateway("popen")
+        return execnet.makegateway("execmodel=main_thread_only//popen")
 
     def setup(self) -> None:
         if hasattr(self, "gateway"):

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -49,7 +49,7 @@ class WorkerSetup:
     def setup(self) -> None:
         self.pytester.chdir()
         # import os ; os.environ['EXECNET_DEBUG'] = "2"
-        self.gateway = execnet.makegateway()
+        self.gateway = execnet.makegateway("execmodel=main_thread_only//popen")
         self.config = config = self.pytester.parseconfigure()
         putevent = self.events.put if self.use_callback else None
 

--- a/testing/test_workermanage.py
+++ b/testing/test_workermanage.py
@@ -83,7 +83,7 @@ class TestNodeManagerPopen:
         assert len(call.specs) == 2
 
         call = hookrecorder.popcall("pytest_xdist_newgateway")
-        assert call.gateway.spec == execnet.XSpec("popen")
+        assert call.gateway.spec == execnet.XSpec("execmodel=main_thread_only//popen")
         assert call.gateway.id == "gw0"
         call = hookrecorder.popcall("pytest_xdist_newgateway")
         assert call.gateway.id == "gw1"
@@ -177,7 +177,7 @@ class TestHRSync:
         assert names == {"dir", "file.txt", "somedir"}
 
     def test_hrsync_one_host(self, source: Path, dest: Path) -> None:
-        gw = execnet.makegateway("popen//chdir=%s" % dest)
+        gw = execnet.makegateway("execmodel=main_thread_only//popen//chdir=%s" % dest)
         finished = []
         rsync = HostRSync(source)
         rsync.add_target_host(gw, finished=lambda: finished.append(1))


### PR DESCRIPTION
Use the execnet `main_thread_only `execmodel so that code which expects to run in the main thread will just work.  This execmodel has been merged to the execnet master branch via pytest-dev/execnet#243, so this patch should not be merged until there is a released version of execnet supporting the `main_thread_only` execmodel.

Also increase minimum python version to 3.8 since execnet dropped 3.7 support in pytest-dev/execnet#245.

Closes: pytest-dev/pytest-xdist#620