### PR TITLE
Avoid modifying path placeholders created by editable installs

### DIFF
--- a/changelog/1028.bugfix
+++ b/changelog/1028.bugfix
@@ -1,0 +1,1 @@
+Fix compatiblity issue between `looponfail` and editable installs.

--- a/src/xdist/looponfail.py
+++ b/src/xdist/looponfail.py
@@ -160,7 +160,8 @@ def init_worker_session(channel, args, option_dict):
     newpaths = []
     for p in sys.path:
         if p:
-            if not os.path.isabs(p):
+            # Ignore path placeholders created for editable installs
+            if not os.path.isabs(p) and not p.endswith(".__path_hook__"):
                 p = os.path.abspath(p)
             newpaths.append(p)
     sys.path[:] = newpaths


### PR DESCRIPTION
The setuptools implementation of editable installs will insert a placeholder entry into sys.path as part of its magic to register its custom import mechanism.

These are not real filesystem paths and as such should not be rewritten to absolute paths.

This is a proposed fix for #1028 .

Checklist:
> - [ ] Make sure to include reasonable tests for your change if necessary

I couldn't figure out how to test this specific behavior, but happy to add one given guidance on how to modify `sys.path` in the test environment.

> - [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file

Added.

