### PR TITLE
Remove pytest InvocationParams backward compat

### DIFF
--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -308,11 +308,6 @@ def getinfodict():
     )
 
 
-def remote_initconfig(option_dict, args):
-    option_dict["plugins"].append("no:terminal")
-    return Config.fromdictargs(option_dict, args)
-
-
 def setup_config(config, basetemp):
     config.option.loadgroup = config.getvalue("dist") == "loadgroup"
     config.option.looponfail = False
@@ -341,11 +336,7 @@ if __name__ == "__channelexec__":
     os.environ["PYTEST_XDIST_WORKER"] = workerinput["workerid"]
     os.environ["PYTEST_XDIST_WORKER_COUNT"] = str(workerinput["workercount"])
 
-    if hasattr(Config, "InvocationParams"):
-        config = _prepareconfig(args, None)
-    else:
-        config = remote_initconfig(option_dict, args)
-        config.args = args
+    config = _prepareconfig(args, None)
 
     setup_config(config, option_dict.get("basetemp"))
     config._parser.prog = os.path.basename(workerinput["mainargv"][0])

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -15,7 +15,7 @@ from typing import Any
 import pytest
 from execnet.gateway_base import dumps, DumpError
 
-from _pytest.config import _prepareconfig, Config
+from _pytest.config import _prepareconfig
 
 try:
     from setproctitle import setproctitle

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -258,12 +258,8 @@ class WorkerController:
     def setup(self):
         self.log("setting up worker session")
         spec = self.gateway.spec
-        if hasattr(self.config, "invocation_params"):
-            args = [str(x) for x in self.config.invocation_params.args or ()]
-            option_dict = {}
-        else:
-            args = self.config.args
-            option_dict = vars(self.config.option)
+        args = [str(x) for x in self.config.invocation_params.args or ()]
+        option_dict = {}
         if not spec.popen or spec.chdir:
             args = make_reltoroot(self.nodemanager.roots, args)
         if spec.popen:

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -70,16 +70,6 @@ def worker(request, pytester: pytest.Pytester) -> WorkerSetup:
     return WorkerSetup(request, pytester)
 
 
-@pytest.mark.xfail(reason="#59")
-def test_remoteinitconfig(pytester: pytest.Pytester) -> None:
-    from xdist.remote import remote_initconfig
-
-    config1 = pytester.parseconfig()
-    config2 = remote_initconfig(config1.option.__dict__, config1.args)
-    assert config2.option.__dict__ == config1.option.__dict__
-    assert config2.pluginmanager.getplugin("terminal") in (-1, None)
-
-
 class TestWorkerInteractor:
     @pytest.fixture
     def unserialize_report(self, pytestconfig):


### PR DESCRIPTION
It's available since pytest 5.2, and pytest-xdist requires pytest>=6.2.