### PR TITLE
Cache execnet gateway rinfo during WorkerController setup

### DIFF
--- a/changelog/1071.bugfix
+++ b/changelog/1071.bugfix
@@ -1,0 +1,1 @@
+Add backward compatibility for deadlock issue with the ``execnet`` new ``main_thread_only`` "execmodel" triggered when pytest-cov accesses rinfo.

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -312,6 +312,11 @@ class WorkerController:
 
     def setup(self) -> None:
         self.log("setting up worker session")
+        # Cache rinfo for backward compatibility, since pytest-cov
+        # accesses rinfo while the main thread is busy executing our
+        # remote_exec call, which triggers a deadlock error for the
+        # main_thread_only execmodel if the rinfo has not been cached.
+        self.gateway._rinfo()
         spec = self.gateway.spec
         args = [str(x) for x in self.config.invocation_params.args or ()]
         option_dict = {}


### PR DESCRIPTION
Cache execnet gateway info during WorkerController setup for backward
compatibility, in order to avoid a later main_thread_only deadlock
error triggered when pytest-cov calls rinfo after the main thread is
already busy. See pytest-dev/execnet#274 for corresponding test case.

Fixes: 20e3ac774e8f ("Use execnet main_thread_only execmodel (#1027)")

I was able not able to reproduce the issue using a small project with pytest-xdist and pytest-cov.

I was able to reproduce it by running tox in a checkout of setuptools, after using pip to install pytest-xdist-3.6.0 into the .tox/py virtualenv. Then I applied this PR to the virtualenv and that fixed the issue, with pytest-cov successfully producing coverage results.