### PR TITLE
Fixed an issue with running the same test multiple times sequentially

### DIFF
--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -183,7 +183,7 @@ class WorkerInteractor:
 
         items = self.session.items
         item = items[self.item_index]
-        if self.nextitem_index is Marker.SHUTDOWN:
+        if self.nextitem_index is Marker.SHUTDOWN or self.item_index == self.nextitem_index:
             nextitem = None
         else:
             assert self.nextitem_index is not None


### PR DESCRIPTION
When pytest_runtest_protocol is called with item==nextitem multiple times, with a test that accepts some fixtures -> the second call forward raises an error.

This is caused in WorkerInteractor when the same test appears twice in a row in the queue.

So if this specific case occurs, ensure nextitem is called with None instead.

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [ ] Make sure to include reasonable tests for your change if necessary

- [ ] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
