### PR TITLE
Make node ID modification more stable.

### DIFF
--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -207,7 +207,7 @@ class WorkerInteractor:
         items: list[pytest.Item],
     ) -> None:
         # add the group name to nodeid as suffix if --dist=loadgroup
-        if config.getvalue("loadgroup"):
+        if config.getoption("dist") == "loadgroup":
             for item in items:
                 mark = item.get_closest_marker("xdist_group")
                 if not mark:
@@ -356,7 +356,6 @@ def getinfodict() -> WorkerInfo:
 
 
 def setup_config(config: pytest.Config, basetemp: str | None) -> None:
-    config.option.loadgroup = config.getvalue("dist") == "loadgroup"
     config.option.looponfail = False
     config.option.usepdb = False
     config.option.dist = "no"


### PR DESCRIPTION
We force test collection on the controller node, as we run some global setup there before starting the workers. That setup also depends on the test node IDs, but currently, pytest-xdist only modifies the test node IDs on the workers, that've been started and where `setup_config` has been called. I don't see a good reason for this, and for creating a separate config entry, so let's just check the right condition in the pytest hook. That way, the hook will always do the same node ID transformation, regardless of pytest-xdist setup.

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [ ] Make sure to include reasonable tests for your change if necessary

- [ ] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
