### PR TITLE
Loadgroup: Don't modify test nodeids any longer.

### DIFF
--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -272,7 +272,10 @@ class DSession:
             terminalreporter.write_sep("=", f"xdist: {self._summary_report}")
 
     def worker_collectionfinish(
-        self, node: WorkerController, ids: Sequence[str]
+        self,
+        node: WorkerController,
+        ids: Sequence[str],
+        loadgroup_scopes: dict[str, str],
     ) -> None:
         """Worker has finished test collection.
 
@@ -290,6 +293,7 @@ class DSession:
         assert self._session is not None
         self._session.testscollected = len(ids)
         assert self.sched is not None
+        self.sched.loadgroup_scopes = loadgroup_scopes
         self.sched.add_node_collection(node, ids)
         if self.terminal:
             self.trdist.setstatus(

--- a/src/xdist/scheduler/loadgroup.py
+++ b/src/xdist/scheduler/loadgroup.py
@@ -52,8 +52,7 @@ class LoadGroupScheduling(LoadScopeScheduling):
             gname
             gname
         """
-        if nodeid.rfind("@") > nodeid.rfind("]"):
-            # check the index of ']' to avoid the case: parametrize mark value has '@'
-            return nodeid.split("@")[-1]
+        if nodeid in self.loadgroup_scopes:
+            return self.loadgroup_scopes[nodeid]
         else:
-            return nodeid
+            return super()._split_scope(nodeid)

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -418,7 +418,12 @@ class WorkerController:
                     rep.item_index = item_index
                 self.notify_inproc(eventname, node=self, rep=rep)
             elif eventname == "collectionfinish":
-                self.notify_inproc(eventname, node=self, ids=kwargs["ids"])
+                self.notify_inproc(
+                    eventname,
+                    node=self,
+                    ids=kwargs["ids"],
+                    loadgroup_scopes=kwargs["loadgroup_scopes"],
+                )
             elif eventname == "runtest_protocol_complete":
                 self.notify_inproc(eventname, node=self, **kwargs)
             elif eventname == "unscheduled":


### PR DESCRIPTION
The loadgroup scheduler used to modify the nodeids of tests that were placed manually in a specific scope. This was used as a side-channel from test collection (on the pytest-running process) to the worker process. Instead, make that side-channel explicit by passing a parameter around.
That's pretty ugly, but no less ugly than modifying and parsing (!) node IDs later on.

I'm not so keen on the "protocol" between the test hook and the schedulers, as we're currently just writing into a field of the currently active scheduler with this implementation.
I previously considered adding this as an extra argument to `add_node_collection`, but that then requires touching _all_ schedulers for something that's only relevant to a single one. Other ideas are welcome here in code review!

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [ ] Make sure to include reasonable tests for your change if necessary

- [ ] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
