### PR TITLE
Create Scheduler for Grouping Tests w/ Variable number of Workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         path: dist
 
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.10.1
+      uses: pypa/gh-action-pypi-publish@v1.10.3
       with:
         attestations: true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Build and Check Package
-      uses: hynek/build-and-inspect-python-package@v2.8
+      uses: hynek/build-and-inspect-python-package@v2.9
 
   deploy:
     needs: package
@@ -39,7 +39,9 @@ jobs:
         path: dist
 
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.9.0
+      uses: pypa/gh-action-pypi-publish@v1.10.1
+      with:
+        attestations: true
 
     - name: Push tag
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
           - "py311-pytestlatest"
           - "py311-pytestmain"
           - "py312-pytestlatest"
+          - "py313-pytestlatest"
           - "py310-psutil"
           - "py310-setproctitle"
 
@@ -60,6 +61,8 @@ jobs:
             python: "3.11"
           - tox_env: "py312-pytestlatest"
             python: "3.12"
+          - tox_env: "py313-pytestlatest"
+            python: "3.13"
           - tox_env: "py310-psutil"
             python: "3.10"
           - tox_env: "py310-setproctitle"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build and Check Package
-      uses: hynek/build-and-inspect-python-package@v2.8
+      uses: hynek/build-and-inspect-python-package@v2.9
 
   test:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: "v0.6.1"
+  rev: "v0.6.5"
   hooks:
     - id: ruff
       args: ["--fix"]
@@ -23,7 +23,7 @@ repos:
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.1
+    rev: v1.11.2
     hooks:
     -   id: mypy
         files: ^(src/|testing/)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: "v0.6.5"
+  rev: "v0.7.0"
   hooks:
     - id: ruff
       args: ["--fix"]
     - id: ruff-format
 -   repo: https://github.com/asottile/blacken-docs
-    rev: 1.18.0
+    rev: 1.19.0
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==23.1.0]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
 -   repo: local
@@ -23,7 +23,7 @@ repos:
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.12.1
     hooks:
     -   id: mypy
         files: ^(src/|testing/)

--- a/changelog/1142.feature.rst
+++ b/changelog/1142.feature.rst
@@ -1,0 +1,1 @@
+Added support for Python 3.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.8"
 dependencies = [

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -402,14 +402,17 @@ class DSession:
                 self.terminal.write_line("")
                 if self.config.option.verbose > 0:
                     self.report_line(f"[-] [dse] scheduling tests via {self.sched.__class__.__name__}")
-            if isinstance(self.sched, CustomGroup) and self.ready_to_run_tests and self.are_all_active_nodes_collected():
-                # we're coming back here after finishing a batch of tests - so start the next batch
-                self.reschedule()
-                self.reset_nodes_if_needed()
+            if isinstance(self.sched, CustomGroup):
+                if self.ready_to_run_tests and self.are_all_active_nodes_collected():
+                    # we're coming back here after finishing a batch of tests - so start the next batch
+                    self.reschedule()
+                    self.reset_nodes_if_needed()
+                else:
+                    self.ready_to_run_tests = True
+                    self.sched.schedule()
+                    self.reset_nodes_if_needed()
             else:
-                self.ready_to_run_tests = True
                 self.sched.schedule()
-                self.reset_nodes_if_needed()
 
     def worker_logstart(
         self,

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -180,7 +180,6 @@ class DSession:
         if self.sched.tests_finished:
             self.triggershutdown()
 
-
     def is_node_finishing(self, node: WorkerController) -> bool:
         """Check if a test worker is considered to be finishing.
 
@@ -191,31 +190,32 @@ class DSession:
         pending = self.sched.node2pending.get(node)
         return pending is not None and len(pending) < 2
 
-
     def are_all_nodes_finishing(self) -> bool:
         """Check if all workers are finishing (See 'is_node_finishing' above)."""
         assert self.sched is not None
         return all(self.is_node_finishing(node) for node in self.sched.nodes)
 
-
     def are_all_nodes_done(self) -> bool:
         """Check if all nodes have reported to finish."""
         return all(s == "finished" for s in self.worker_status.values())
-
 
     def are_all_active_nodes_collected(self) -> bool:
         """Check if all nodes have reported collection to be complete."""
         if not all(n.gateway.id in self.worker_status for n in self._active_nodes):
             return False
-        return all(self.worker_status[n.gateway.id] == "collected" for n in self._active_nodes)
-
+        return all(
+            self.worker_status[n.gateway.id] == "collected" for n in self._active_nodes
+        )
 
     def reset_nodes_if_needed(self) -> None:
         assert self.sched is not None
         assert type(self.sched) is CustomGroup
-        if self.are_all_nodes_finishing() and self.ready_to_run_tests and not self.sched.do_resched:
+        if (
+            self.are_all_nodes_finishing()
+            and self.ready_to_run_tests
+            and not self.sched.do_resched
+        ):
             self.reset_nodes()
-
 
     def reset_nodes(self) -> None:
         """Issue shutdown notices to workers for rescheduling purposes."""
@@ -227,7 +227,6 @@ class DSession:
             if self.is_node_finishing(node):
                 node.shutdown()
 
-
     def reschedule(self) -> None:
         """Reschedule tests."""
         assert self.sched is not None
@@ -235,13 +234,14 @@ class DSession:
         self.sched.do_resched = False
         self.sched.check_schedule(self.sched.nodes[0], 1.0, True)
 
-
     def prepare_for_reschedule(self) -> None:
         """Update test workers and their status tracking so rescheduling is ready."""
         assert type(self.sched) is CustomGroup
         assert self.sched is not None
         self.remake_nodes = False
-        num_workers = self.sched.dist_groups[self.sched.pending_groups[0]]['group_workers']
+        num_workers = self.sched.dist_groups[self.sched.pending_groups[0]][
+            "group_workers"
+        ]
         self.trdist._status = {}
         assert self.nodemanager is not None
         new_nodes = self.nodemanager.setup_nodes(self.saved_put, num_workers)
@@ -295,8 +295,10 @@ class DSession:
                 try:
                     self.prepare_for_reschedule()
                 except Exception as e:
-                    msg = ("Exception caught during preparation for rescheduling. Giving up."
-                           f"\n{''.join(traceback.format_exception(e))}")
+                    msg = (
+                        "Exception caught during preparation for rescheduling. Giving up."
+                        f"\n{''.join(traceback.format_exception(e))}"
+                    )
                     self.shouldstop = msg
             return
         self.config.hook.pytest_testnodedown(node=node, error=None)
@@ -392,7 +394,9 @@ class DSession:
         scheduling the first time it logs which scheduler is in use.
         """
         if self.shuttingdown:
-            self.report_line(f"[-] [dse] collectionfinish while closing {node.gateway.id}")
+            self.report_line(
+                f"[-] [dse] collectionfinish while closing {node.gateway.id}"
+            )
             return
         self.update_worker_status(node, "collected")
 
@@ -412,7 +416,9 @@ class DSession:
                 self.trdist.ensure_show_status()
                 self.terminal.write_line("")
                 if self.config.option.verbose > 0:
-                    self.report_line(f"[-] [dse] scheduling tests via {self.sched.__class__.__name__}")
+                    self.report_line(
+                        f"[-] [dse] scheduling tests via {self.sched.__class__.__name__}"
+                    )
             if isinstance(self.sched, CustomGroup):
                 if self.ready_to_run_tests and self.are_all_active_nodes_collected():
                     # we're coming back here after finishing a batch of tests - so start the next batch

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -108,6 +108,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "loadfile",
             "loadgroup",
             "worksteal",
+            "customgroup",
             "no",
         ],
         dest="dist",
@@ -124,6 +125,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "loadgroup: Like 'load', but sends tests marked with 'xdist_group' to the same worker.\n\n"
             "worksteal: Split the test suite between available environments,"
             " then re-balance when any worker runs out of tests.\n\n"
+            # TODO: Update docstring
+            "customgroup: TODO: add docs here"
             "(default) no: Run tests inprocess, don't distribute."
         ),
     )

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -201,15 +201,17 @@ class WorkerInteractor:
             "runtest_protocol_complete", item_index=self.item_index, duration=duration
         )
 
+    @pytest.mark.trylast
     def pytest_collection_modifyitems(
         self,
         config: pytest.Config,
         items: list[pytest.Item],
     ) -> None:
         # add the group name to nodeid as suffix if --dist=loadgroup
-        if config.getvalue("loadgroup"):
+        if config.getvalue("loadgroup") or config.getvalue("customgroup"):
+            functional_mark = "xdist_group" if config.getvalue("loadgroup") else "xdist_custom"
             for item in items:
-                mark = item.get_closest_marker("xdist_group")
+                mark = item.get_closest_marker(functional_mark)
                 if not mark:
                     continue
                 gname = (
@@ -357,6 +359,7 @@ def getinfodict() -> WorkerInfo:
 
 def setup_config(config: pytest.Config, basetemp: str | None) -> None:
     config.option.loadgroup = config.getvalue("dist") == "loadgroup"
+    config.option.customgroup = config.getvalue("dist") == "customgroup"
     config.option.looponfail = False
     config.option.usepdb = False
     config.option.dist = "no"

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -209,7 +209,9 @@ class WorkerInteractor:
     ) -> None:
         # add the group name to nodeid as suffix if --dist=loadgroup
         if config.getvalue("loadgroup") or config.getvalue("customgroup"):
-            functional_mark = "xdist_group" if config.getvalue("loadgroup") else "xdist_custom"
+            functional_mark = (
+                "xdist_group" if config.getvalue("loadgroup") else "xdist_custom"
+            )
             for item in items:
                 mark = item.get_closest_marker(functional_mark)
                 if not mark:

--- a/src/xdist/scheduler/__init__.py
+++ b/src/xdist/scheduler/__init__.py
@@ -1,5 +1,6 @@
 from xdist.scheduler.each import EachScheduling as EachScheduling
 from xdist.scheduler.load import LoadScheduling as LoadScheduling
+from xdist.scheduler.customgroup import CustomGroup as CustomGroup
 from xdist.scheduler.loadfile import LoadFileScheduling as LoadFileScheduling
 from xdist.scheduler.loadgroup import LoadGroupScheduling as LoadGroupScheduling
 from xdist.scheduler.loadscope import LoadScopeScheduling as LoadScopeScheduling

--- a/src/xdist/scheduler/__init__.py
+++ b/src/xdist/scheduler/__init__.py
@@ -1,6 +1,6 @@
+from xdist.scheduler.customgroup import CustomGroup as CustomGroup
 from xdist.scheduler.each import EachScheduling as EachScheduling
 from xdist.scheduler.load import LoadScheduling as LoadScheduling
-from xdist.scheduler.customgroup import CustomGroup as CustomGroup
 from xdist.scheduler.loadfile import LoadFileScheduling as LoadFileScheduling
 from xdist.scheduler.loadgroup import LoadGroupScheduling as LoadGroupScheduling
 from xdist.scheduler.loadscope import LoadScopeScheduling as LoadScopeScheduling

--- a/src/xdist/scheduler/customgroup.py
+++ b/src/xdist/scheduler/customgroup.py
@@ -1,0 +1,365 @@
+"""Run tests across a variable number of nodes based on custom groups.
+
+# TODO: This is more of a spec/description, update docs/remove this section document within the class
+Example:
+    - 10 test cases exist
+    - 4 test cases are marked with @pytest.mark.low
+    - 4 test cases are marked with @pytest.mark.medium
+    - 2 test cases are marked with @pytest.mark.high
+    - A pytest.ini file contains the following lines:
+[pytest]
+
+markers=
+    low: 4
+    medium: 2
+    high: 1
+
+Then the 4 low test cases will be ran on 4 workers (distributed evenly amongst the 4, as the load.py scheduler functions)
+Then the 4 medium test cases will be ran on 2 workers (again, distributed evenly), only after the low test cases are complete (or before they start).
+Then the 2 high test cases will be ran on 1 worker (distributed evenly), only after the low and medium test cases are complete (or before they start).
+
+This allows a pytest user more custom control over processing tests.
+One potential application would be measuring the resource utilization of all test cases. Test cases that are not
+resource intensive can be ran on many workers, and more resource intensive test cases can be ran once the low
+resource consuming tests are done on fewer workers, such that resource consumption does not exceed available resources.
+"""
+from __future__ import annotations
+
+from itertools import cycle
+from typing import Sequence
+
+import pytest
+
+from xdist.remote import Producer, WorkerInteractor
+from xdist.report import report_collection_diff
+from xdist.workermanage import parse_spec_config
+from xdist.workermanage import WorkerController
+
+class CustomGroup:
+    """
+    # TODO: update docs here
+    """
+
+    def __init__(self, config: pytest.Config, log: Producer | None = None) -> None:
+        self.terminal = config.pluginmanager.getplugin("terminalreporter")
+        self.numnodes = len(parse_spec_config(config))
+        self.node2collection: dict[WorkerController, list[str]] = {}
+        self.node2pending: dict[WorkerController, list[int]] = {}
+        self.pending: list[int] = []
+        self.collection: list[str] | None = None
+        if log is None:
+            self.log = Producer("loadsched")
+        else:
+            self.log = log.loadsched
+        self.config = config
+        self.maxschedchunk = self.config.getoption("maxschedchunk")
+        # TODO: Type annotation incorrect
+        self.dist_groups: dict[str, str] = {}
+        self.pending_groups: list[str] = []
+        self.is_first_time = True
+        self.do_resched = False
+
+    @property
+    def nodes(self) -> list[WorkerController]:
+        """A list of all nodes in the scheduler."""
+        return list(self.node2pending.keys())
+
+    @property
+    def collection_is_completed(self) -> bool:
+        """Boolean indication initial test collection is complete.
+
+        This is a boolean indicating all initial participating nodes
+        have finished collection.  The required number of initial
+        nodes is defined by ``.numnodes``.
+        """
+        return len(self.node2collection) >= self.numnodes
+
+    @property
+    def tests_finished(self) -> bool:
+        """Return True if all tests have been executed by the nodes."""
+        if not self.collection_is_completed:
+            return False
+        if self.pending:
+            return False
+        for pending in self.node2pending.values():
+            if len(pending) >= 2:
+                return False
+        return True
+
+    @property
+    def has_pending(self) -> bool:
+        """Return True if there are pending test items.
+
+        This indicates that collection has finished and nodes are
+        still processing test items, so this can be thought of as
+        "the scheduler is active".
+        """
+        if self.pending:
+            return True
+        for pending in self.node2pending.values():
+            if pending:
+                return True
+        return False
+
+    def add_node(self, node: WorkerController) -> None:
+        """Add a new node to the scheduler.
+
+        From now on the node will be allocated chunks of tests to
+        execute.
+
+        Called by the ``DSession.worker_workerready`` hook when it
+        successfully bootstraps a new node.
+        """
+        assert node not in self.node2pending
+        self.node2pending[node] = []
+
+    def add_node_collection(
+        self, node: WorkerController, collection: Sequence[str]
+    ) -> None:
+        """Add the collected test items from a node.
+
+        The collection is stored in the ``.node2collection`` map.
+        Called by the ``DSession.worker_collectionfinish`` hook.
+        """
+        assert node in self.node2pending
+        if self.collection_is_completed:
+            # A new node has been added later, perhaps an original one died.
+            # .schedule() should have
+            # been called by now
+            assert self.collection
+            if collection != self.collection:
+                other_node = next(iter(self.node2collection.keys()))
+                msg = report_collection_diff(
+                    self.collection, collection, other_node.gateway.id, node.gateway.id
+                )
+                self.log(msg)
+                return
+        self.node2collection[node] = list(collection)
+
+    def mark_test_complete(
+        self, node: WorkerController, item_index: int, duration: float = 0
+    ) -> None:
+        """Mark test item as completed by node.
+
+        The duration it took to execute the item is used as a hint to
+        the scheduler.
+
+        This is called by the ``DSession.worker_testreport`` hook.
+        """
+        self.node2pending[node].remove(item_index)
+        self.check_schedule(node, duration=duration)
+
+    def mark_test_pending(self, item: str) -> None:
+
+        assert self.collection is not None
+        self.pending.insert(
+            0,
+            self.collection.index(item),
+        )
+        for node in self.node2pending:
+            self.check_schedule(node)
+
+    def remove_pending_tests_from_node(
+        self,
+        node: WorkerController,
+        indices: Sequence[int],
+    ) -> None:
+        raise NotImplementedError()
+
+    def check_schedule(self, node: WorkerController, duration: float = 0, from_dsession=False) -> None:
+        """Maybe schedule new items on the node.
+
+        If there are any globally pending nodes left then this will
+        check if the given node should be given any more tests.  The
+        ``duration`` of the last test is optionally used as a
+        heuristic to influence how many tests the node is assigned.
+        """
+        if node.shutting_down:
+            self.report_line(f"[-] [csg] {node.workerinput['workerid']} is already shutting down")
+            return
+
+        if self.pending:
+            any_working = False
+            for node in self.nodes:
+                if len(self.node2pending[node]) not in [0, 1]:
+                    any_working = True
+
+            if not any_working and from_dsession:
+                if self.pending_groups:
+                    dist_group_key = self.pending_groups.pop(0)
+                    dist_group = self.dist_groups[dist_group_key]
+                    nodes = cycle(self.nodes[0:dist_group['group_workers']])
+                    schedule_log = {n.gateway.id:[] for n in self.nodes[0:dist_group['group_workers']]}
+                    for _ in range(len(dist_group['test_indices'])):
+                        n = next(nodes)
+                        #needs cleaner way to be identified
+                        tests_per_node = self.dist_groups[dist_group_key]['pending_indices'][:1]
+                        schedule_log[n.gateway.id].extend(tests_per_node)
+
+                        self._send_tests_group(n, 1, dist_group_key)
+                    del self.dist_groups[dist_group_key]
+                    message = f"\n[-] [csg] check_schedule: processed scheduling for {dist_group_key}: {' '.join([f'{nid} ({len(nt)})' for nid,nt in schedule_log.items()])}"
+                    self.report_line(message)
+
+        else:
+            pending = self.node2pending.get(node)
+            if len(pending) < 2:
+                self.report_line(f"[-] [csg] Shutting down {node.workerinput['workerid']} because only one case is pending")
+                node.shutdown()
+
+        self.log("num items waiting for node:", len(self.pending))
+
+    def remove_node(self, node: WorkerController) -> str | None:
+        """Remove a node from the scheduler.
+
+        This should be called either when the node crashed or at
+        shutdown time.  In the former case any pending items assigned
+        to the node will be re-scheduled.  Called by the
+        ``DSession.worker_workerfinished`` and
+        ``DSession.worker_errordown`` hooks.
+
+        Return the item which was being executing while the node
+        crashed or None if the node has no more pending items.
+
+        """
+        pending = self.node2pending.pop(node)
+        if not pending:
+            return None
+
+        # The node crashed, reassing pending items
+        assert self.collection is not None
+        crashitem = self.collection[pending.pop(0)]
+        self.pending.extend(pending)
+        for node in self.node2pending:
+            self.check_schedule(node)
+        return crashitem
+
+    def schedule(self) -> None:
+        """Initiate distribution of the test collection.
+
+        Initiate scheduling of the items across the nodes.  If this
+        gets called again later it behaves the same as calling
+        ``.check_schedule()`` on all nodes so that newly added nodes
+        will start to be used.
+
+        This is called by the ``DSession.worker_collectionfinish`` hook
+        if ``.collection_is_completed`` is True.
+        """
+        assert self.collection_is_completed
+
+        # Initial distribution already happened, reschedule on all nodes
+        if self.collection is not None:
+            for node in self.nodes:
+                self.check_schedule(node)
+            return
+
+        # XXX allow nodes to have different collections
+        if not self._check_nodes_have_same_collection():
+            self.log("**Different tests collected, aborting run**")
+            return
+
+        # Collections are identical, create the index of pending items.
+        self.collection = next(iter(self.node2collection.values()))
+        self.pending[:] = range(len(self.collection))
+        if not self.collection:
+            return
+
+        if self.maxschedchunk is None:
+            self.maxschedchunk = len(self.collection)
+
+        dist_groups = {}
+
+        if self.is_first_time:
+            for i, test in enumerate(self.collection):
+                if '@' in test:
+                    group_mark = test.split('@')[-1]
+                    group_workers = int(group_mark.split('_')[-1])
+                    if group_workers > len(self.nodes):
+                        # We can only distribute across as many nodes as we have available
+                        # If a group requests more, we fallback to our actual max
+                        group_workers = len(self.nodes)
+                else:
+                    group_mark = 'default'
+                    group_workers = len(self.nodes)
+                existing_tests = dist_groups.get(group_mark, {}).get('tests', [])
+                existing_tests.append(test)
+                existing_indices = dist_groups.get(group_mark, {}).get('test_indices', [])
+                existing_indices.append(i)
+
+                dist_groups[group_mark] = {
+                    'tests': existing_tests,
+                    'group_workers': group_workers,
+                    'test_indices': existing_indices,
+                    'pending_indices': existing_indices
+                }
+            self.dist_groups = dist_groups
+            self.pending_groups = list(dist_groups.keys())
+            self.is_first_time = False
+        else:
+            for node in self.nodes:
+                self.check_schedule(node)
+
+        if not self.pending_groups:
+            return
+        dist_group_key = self.pending_groups.pop(0)
+        dist_group = self.dist_groups[dist_group_key]
+        nodes = cycle(self.nodes[0:dist_group['group_workers']])
+        schedule_log = {n.gateway.id: [] for n in self.nodes[0:dist_group['group_workers']]}
+        for _ in range(len(dist_group['test_indices'])):
+            n = next(nodes)
+            # needs cleaner way to be identified
+            tests_per_node = self.dist_groups[dist_group_key]['pending_indices'][:1]
+            schedule_log[n.gateway.id].extend(tests_per_node)
+            self._send_tests_group(n, 1, dist_group_key)
+        del self.dist_groups[dist_group_key]
+        message = f"\n[-] [csg] schedule: processed scheduling for {dist_group_key}: {' '.join([f'{nid} ({len(nt)})' for nid, nt in schedule_log.items()])}"
+        self.report_line(message)
+
+    def _send_tests(self, node: WorkerController, num: int) -> None:
+        tests_per_node = self.pending[:num]
+        if tests_per_node:
+            del self.pending[:num]
+            self.node2pending[node].extend(tests_per_node)
+            node.send_runtest_some(tests_per_node)
+
+    def _send_tests_group(self, node: WorkerController, num: int, dist_group_key) -> None:
+        tests_per_node = self.dist_groups[dist_group_key]['pending_indices'][:num]
+        if tests_per_node:
+            del self.dist_groups[dist_group_key]['pending_indices'][:num]
+            for test_index in tests_per_node:
+                self.pending.remove(test_index)
+            self.node2pending[node].extend(tests_per_node)
+            node.send_runtest_some(tests_per_node)
+
+
+    def _check_nodes_have_same_collection(self) -> bool:
+        """Return True if all nodes have collected the same items.
+
+        If collections differ, this method returns False while logging
+        the collection differences and posting collection errors to
+        pytest_collectreport hook.
+        """
+        node_collection_items = list(self.node2collection.items())
+        first_node, col = node_collection_items[0]
+        same_collection = True
+        for node, collection in node_collection_items[1:]:
+            msg = report_collection_diff(
+                col, collection, first_node.gateway.id, node.gateway.id
+            )
+            if msg:
+                same_collection = False
+                self.log(msg)
+                if self.config is not None:
+                    rep = pytest.CollectReport(
+                        nodeid=node.gateway.id,
+                        outcome="failed",
+                        longrepr=msg,
+                        result=[],
+                    )
+                    self.config.hook.pytest_collectreport(report=rep)
+
+        return same_collection
+
+    def report_line(self, line: str) -> None:
+        if self.terminal and self.config.option.verbose >= 0:
+            self.terminal.write_line(line)

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -11,6 +11,7 @@ from typing import Callable
 from typing import Literal
 from typing import Sequence
 from typing import Union
+from typing import Optional
 import uuid
 import warnings
 
@@ -82,9 +83,12 @@ class NodeManager:
     def setup_nodes(
         self,
         putevent: Callable[[tuple[str, dict[str, Any]]], None],
+        max_nodes: Optional[int] = None    
     ) -> list[WorkerController]:
         self.config.hook.pytest_xdist_setupnodes(config=self.config, specs=self.specs)
         self.trace("setting up nodes")
+        if max_nodes:
+            return [self.setup_node(spec, putevent) for spec in self.specs[0:max_nodes]]
         return [self.setup_node(spec, putevent) for spec in self.specs]
 
     def setup_node(

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -11,7 +11,6 @@ from typing import Callable
 from typing import Literal
 from typing import Sequence
 from typing import Union
-from typing import Optional
 import uuid
 import warnings
 
@@ -83,7 +82,7 @@ class NodeManager:
     def setup_nodes(
         self,
         putevent: Callable[[tuple[str, dict[str, Any]]], None],
-        max_nodes: Optional[int] = None    
+        max_nodes: int | None = None
     ) -> list[WorkerController]:
         self.config.hook.pytest_xdist_setupnodes(config=self.config, specs=self.specs)
         self.trace("setting up nodes")

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -82,7 +82,7 @@ class NodeManager:
     def setup_nodes(
         self,
         putevent: Callable[[tuple[str, dict[str, Any]]], None],
-        max_nodes: int | None = None
+        max_nodes: int | None = None,
     ) -> list[WorkerController]:
         self.config.hook.pytest_xdist_setupnodes(config=self.config, specs=self.specs)
         self.trace("setting up nodes")

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
   linting
-  py{38,39,310,311,312}-pytestlatest
+  py{38,39,310,311,312,313}-pytestlatest
   py310-pytestmain
   py310-psutil
   py310-setproctitle

--- a/xdist-testing-ntop/README.md
+++ b/xdist-testing-ntop/README.md
@@ -1,0 +1,14 @@
+# Testing pytest-xdist Scheduler Custumization
+- Run with `python -m pytest test.py` to run tests
+- Run with `python -m pytest test.py -n <max worker count> --dist customgroup --junit-xml results.xml -v` to use new scheduler + report to xml and have verbose terminal output
+    - Verbose terminal output is semi-required when using customgroup. It allows the user to confirm the correct tests are running with the correct number of processes.
+
+## Notes:
+- Install local pytest with `python -m pip install .` or `python -m pip install -e .`
+    - When ran from root of `pytest-xdist` repository
+
+## Using Customgroup
+- Add pytest mark `xdist_custom(name="<group_name>_<num_workers>")` to tests
+    - Tests without this marking will use the maximum worker count specified by `-n` argument
+- Add `xdist_custom` to `pytest.ini` to avoid warnings about unregistered marks
+- Run tests as detailed above

--- a/xdist-testing-ntop/pytest.ini
+++ b/xdist-testing-ntop/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli_level=0
+
+markers=
+    xdist_custom

--- a/xdist-testing-ntop/test.py
+++ b/xdist-testing-ntop/test.py
@@ -1,0 +1,94 @@
+import pytest
+import time
+
+
+@pytest.mark.xdist_custom(name="low_4")
+def test_1():
+    time.sleep(2)
+    assert True
+
+@pytest.mark.xdist_custom(name="low_4")
+def test_2():
+    time.sleep(2)
+    assert True
+
+@pytest.mark.xdist_custom(name="low_4")
+def test_3():
+    time.sleep(2)
+    assert True
+
+@pytest.mark.xdist_custom(name="low_4")
+def test_4():
+    time.sleep(2)
+    assert True
+
+# @pytest.mark.xdist_custom(name="low_4")
+# def test_4a():
+#     time.sleep(2)
+#     assert True
+#
+# @pytest.mark.xdist_custom(name="low_4")
+# def test_4b():
+#     time.sleep(2)
+#     assert True
+#
+# @pytest.mark.xdist_custom(name="low_4")
+# def test_4c():
+#     time.sleep(2)
+#     assert True
+#
+# @pytest.mark.xdist_custom(name="low_4")
+# def test_4d():
+#     time.sleep(2)
+#     assert True
+#
+# @pytest.mark.xdist_custom(name="low_4")
+# def test_4e():
+#     time.sleep(2)
+#     assert True
+
+@pytest.mark.xdist_custom(name="med_2")
+def test_5():
+    time.sleep(3)
+    assert True
+
+@pytest.mark.xdist_custom(name="med_2")
+def test_6():
+    time.sleep(3)
+    assert True
+
+@pytest.mark.xdist_custom(name="med_2")
+def test_7():
+    time.sleep(3)
+    assert True
+
+@pytest.mark.xdist_custom(name="med_2")
+def test_8():
+    time.sleep(3)
+    assert True
+
+@pytest.mark.xdist_custom(name="high_1")
+def test_9():
+    time.sleep(5)
+    assert True
+
+@pytest.mark.xdist_custom(name="high_1")
+def test_10():
+    time.sleep(5)
+    assert True
+
+def test_11():
+    time.sleep(1)
+    assert True
+
+def test_12():
+    time.sleep(1)
+    assert True
+
+def test_13():
+    time.sleep(1)
+    assert True
+
+def test_14():
+    time.sleep(1)
+    assert True

--- a/xdist-testing-ntop/test.py
+++ b/xdist-testing-ntop/test.py
@@ -1,5 +1,6 @@
-import pytest
 import time
+
+import pytest
 
 
 @pytest.mark.xdist_custom(name="low_4")

--- a/xdist-testing-ntop/test.py
+++ b/xdist-testing-ntop/test.py
@@ -8,20 +8,24 @@ def test_1():
     time.sleep(2)
     assert True
 
+
 @pytest.mark.xdist_custom(name="low_4")
 def test_2():
     time.sleep(2)
     assert True
+
 
 @pytest.mark.xdist_custom(name="low_4")
 def test_3():
     time.sleep(2)
     assert True
 
+
 @pytest.mark.xdist_custom(name="low_4")
 def test_4():
     time.sleep(2)
     assert True
+
 
 # @pytest.mark.xdist_custom(name="low_4")
 # def test_4a():
@@ -48,47 +52,57 @@ def test_4():
 #     time.sleep(2)
 #     assert True
 
+
 @pytest.mark.xdist_custom(name="med_2")
 def test_5():
     time.sleep(3)
     assert True
+
 
 @pytest.mark.xdist_custom(name="med_2")
 def test_6():
     time.sleep(3)
     assert True
 
+
 @pytest.mark.xdist_custom(name="med_2")
 def test_7():
     time.sleep(3)
     assert True
+
 
 @pytest.mark.xdist_custom(name="med_2")
 def test_8():
     time.sleep(3)
     assert True
 
+
 @pytest.mark.xdist_custom(name="high_1")
 def test_9():
     time.sleep(5)
     assert True
+
 
 @pytest.mark.xdist_custom(name="high_1")
 def test_10():
     time.sleep(5)
     assert True
 
+
 def test_11():
     time.sleep(1)
     assert True
+
 
 def test_12():
     time.sleep(1)
     assert True
 
+
 def test_13():
     time.sleep(1)
     assert True
+
 
 def test_14():
     time.sleep(1)


### PR DESCRIPTION
This pull request addresses [Issue 1014](https://github.com/pytest-dev/pytest-xdist/issues/1014). It adds a new scheduler that allows a user to add tests to arbitrary groups using the pytest mark `xdist_custom`. Using the mark a group name and number of workers to use for that group is specified. Groups are ran sequentially but tests in each group are ran in parallel with the given number of workers.

**This pull request is a rough prototype. We aren't too familiar with pytest-xdist internals and we don't expect it is merge-able as is. However, we're hoping to open the conversation to see if there are improvements we can make to get this merged into pytest-xdist.**

Since we wanted groups of tests to execute sequentially, we did not want to schedule tests from a pending group until after the currently running group completed all tests. We found that in order to obtain the status of the final test scheduled on a worker, we needed to send a shutdown signal to the worker. Because of this, between groups a shutdown signal is sent to each worker, and then workers are initialized again prior to scheduling the next group of tests.

We left the directory `xdist-testing-ntop` in as an example but will remove that and add proper tests.

Will add a `changelog/1014.feature` if this PR gains traction.
