### PR TITLE
Allow custom scheduler names in `--dist` command line argument

### DIFF
--- a/changelog/970.feature
+++ b/changelog/970.feature
@@ -1,0 +1,1 @@
+`--dist` option allows custom scheduler names now.

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -101,15 +101,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--dist",
         metavar="distmode",
         action="store",
-        choices=[
-            "each",
-            "load",
-            "loadscope",
-            "loadfile",
-            "loadgroup",
-            "worksteal",
-            "no",
-        ],
         dest="dist",
         default="no",
         help=(
@@ -235,6 +226,13 @@ def pytest_configure(config: pytest.Config) -> None:
     # Create the distributed session in case we have a valid distribution
     # mode and test environments.
     if _is_distribution_mode(config):
+        config.pluginmanager.import_plugin("xdist.scheduler.each")
+        config.pluginmanager.import_plugin("xdist.scheduler.load")
+        config.pluginmanager.import_plugin("xdist.scheduler.loadfile")
+        config.pluginmanager.import_plugin("xdist.scheduler.loadgroup")
+        config.pluginmanager.import_plugin("xdist.scheduler.loadscope")
+        config.pluginmanager.import_plugin("xdist.scheduler.worksteal")
+
         from xdist.dsession import DSession
 
         session = DSession(config)

--- a/src/xdist/scheduler/each.py
+++ b/src/xdist/scheduler/each.py
@@ -6,6 +6,7 @@ import pytest
 
 from xdist.remote import Producer
 from xdist.report import report_collection_diff
+from xdist.scheduler.protocol import Scheduling
 from xdist.workermanage import parse_spec_config
 from xdist.workermanage import WorkerController
 
@@ -150,3 +151,14 @@ class EachScheduling:
             else:
                 node.send_runtest_some(pending)
             self._started.append(node)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_xdist_make_scheduler(
+    config: pytest.Config,
+    log: Producer,
+) -> Scheduling | None:
+    if config.getoption("dist") == "each":
+        return EachScheduling(config, log)
+    else:
+        return None

--- a/src/xdist/scheduler/load.py
+++ b/src/xdist/scheduler/load.py
@@ -7,6 +7,7 @@ import pytest
 
 from xdist.remote import Producer
 from xdist.report import report_collection_diff
+from xdist.scheduler.protocol import Scheduling
 from xdist.workermanage import parse_spec_config
 from xdist.workermanage import WorkerController
 
@@ -333,3 +334,14 @@ class LoadScheduling:
                     self.config.hook.pytest_collectreport(report=rep)
 
         return same_collection
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_xdist_make_scheduler(
+    config: pytest.Config,
+    log: Producer,
+) -> Scheduling | None:
+    if config.getoption("dist") == "load":
+        return LoadScheduling(config, log)
+    else:
+        return None

--- a/src/xdist/scheduler/loadfile.py
+++ b/src/xdist/scheduler/loadfile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from xdist.remote import Producer
+from xdist.scheduler.protocol import Scheduling
 
 from .loadscope import LoadScopeScheduling
 
@@ -58,3 +59,14 @@ class LoadFileScheduling(LoadScopeScheduling):
             example/loadsuite/epsilon/__init__.py
         """
         return nodeid.split("::", 1)[0]
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_xdist_make_scheduler(
+    config: pytest.Config,
+    log: Producer,
+) -> Scheduling | None:
+    if config.getoption("dist") == "loadfile":
+        return LoadFileScheduling(config, log)
+    else:
+        return None

--- a/src/xdist/scheduler/loadgroup.py
+++ b/src/xdist/scheduler/loadgroup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from xdist.remote import Producer
+from xdist.scheduler.protocol import Scheduling
 
 from .loadscope import LoadScopeScheduling
 
@@ -57,3 +58,14 @@ class LoadGroupScheduling(LoadScopeScheduling):
             return nodeid.split("@")[-1]
         else:
             return nodeid
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_xdist_make_scheduler(
+    config: pytest.Config,
+    log: Producer,
+) -> Scheduling | None:
+    if config.getoption("dist") == "loadgroup":
+        return LoadGroupScheduling(config, log)
+    else:
+        return None

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -8,6 +8,7 @@ import pytest
 
 from xdist.remote import Producer
 from xdist.report import report_collection_diff
+from xdist.scheduler.protocol import Scheduling
 from xdist.workermanage import parse_spec_config
 from xdist.workermanage import WorkerController
 
@@ -432,3 +433,14 @@ class LoadScopeScheduling:
             self.config.hook.pytest_collectreport(report=rep)
 
         return same_collection
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_xdist_make_scheduler(
+    config: pytest.Config,
+    log: Producer,
+) -> Scheduling | None:
+    if config.getoption("dist") == "loadscope":
+        return LoadScopeScheduling(config, log)
+    else:
+        return None

--- a/src/xdist/scheduler/worksteal.py
+++ b/src/xdist/scheduler/worksteal.py
@@ -7,6 +7,7 @@ import pytest
 
 from xdist.remote import Producer
 from xdist.report import report_collection_diff
+from xdist.scheduler.protocol import Scheduling
 from xdist.workermanage import parse_spec_config
 from xdist.workermanage import WorkerController
 
@@ -343,3 +344,14 @@ class WorkStealingScheduling:
                     self.config.hook.pytest_collectreport(report=rep)
 
         return same_collection
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_xdist_make_scheduler(
+    config: pytest.Config,
+    log: Producer,
+) -> Scheduling | None:
+    if config.getoption("dist") == "worksteal":
+        return WorkStealingScheduling(config, log)
+    else:
+        return None

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1641,3 +1641,15 @@ def test_dist_in_addopts(pytester: pytest.Pytester) -> None:
     )
     result = pytester.runpytest()
     assert result.ret == 0
+
+
+def test_dist_validation(pytester: pytest.Pytester) -> None:
+    """Should exit early if incorrect --dist value is specified."""
+    f = pytester.makepyfile(
+        """
+        assert 0
+        """
+    )
+    result = pytester.runpytest(f, "-n1", "--dist=invalid")
+    assert result.ret == pytest.ExitCode.USAGE_ERROR
+    result.stderr.fnmatch_lines(["ERROR: pytest-xdist: scheduler 'invalid' not found"])


### PR DESCRIPTION
There seems to be no way to fix the argument validation, at least without complicating things unnecessarily.

So simply remove it. Instead, check `pytest_xdist_make_scheduler` return value.

Also, convert every built-in scheduler to a separate plugin.

Fixes: https://github.com/pytest-dev/pytest-xdist/issues/970