### PR TITLE
Drop EOL Python 3.8 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         tox_env:
-          - "py38-pytestmin"
-          - "py38-pytestlatest"
+          - "py39-pytestmin"
           - "py39-pytestlatest"
           - "py310-pytestlatest"
           - "py311-pytestlatest"
@@ -47,10 +46,8 @@ jobs:
 
         os: [ubuntu-latest, windows-latest]
         include:
-          - tox_env: "py38-pytestmin"
-            python: "3.8"
-          - tox_env: "py38-pytestlatest"
-            python: "3.8"
+          - tox_env: "py39-pytestmin"
+            python: "3.9"
           - tox_env: "py39-pytestlatest"
             python: "3.9"
           - tox_env: "py310-pytestlatest"

--- a/changelog/1162.removal.rst
+++ b/changelog/1162.removal.rst
@@ -1,0 +1,1 @@
+Dropped support for EOL Python 3.8.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,13 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "execnet>=2.1",
     "pytest>=7.0.0",

--- a/src/xdist/_path.py
+++ b/src/xdist/_path.py
@@ -1,8 +1,8 @@
+from collections.abc import Iterator
 from itertools import chain
 import os
 from pathlib import Path
 from typing import Callable
-from typing import Iterator
 
 
 def visit_path(

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from enum import auto
 from enum import Enum
 from queue import Empty
 from queue import Queue
 import sys
 from typing import Any
-from typing import Sequence
 import warnings
 
 import execnet

--- a/src/xdist/looponfail.py
+++ b/src/xdist/looponfail.py
@@ -9,12 +9,12 @@ the controlling process which should best never happen.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 import os
 from pathlib import Path
 import sys
 import time
 from typing import Any
-from typing import Sequence
 
 from _pytest._io import TerminalWriter
 import execnet
@@ -158,9 +158,9 @@ def repr_pytest_looponfailinfo(
 
 
 def init_worker_session(
-    channel: "execnet.Channel",  # noqa: UP037
+    channel: execnet.Channel,
     args: list[str],
-    option_dict: dict[str, "Any"],  # noqa: UP037
+    option_dict: dict[str, Any],
 ) -> None:
     import os
     import sys

--- a/src/xdist/looponfail.py
+++ b/src/xdist/looponfail.py
@@ -158,9 +158,9 @@ def repr_pytest_looponfailinfo(
 
 
 def init_worker_session(
-    channel: execnet.Channel,
+    channel: "execnet.Channel",  # noqa: UP037
     args: list[str],
-    option_dict: dict[str, Any],
+    option_dict: dict[str, "Any"],  # noqa: UP037
 ) -> None:
     import os
     import sys

--- a/src/xdist/newhooks.py
+++ b/src/xdist/newhooks.py
@@ -14,9 +14,9 @@ must be taken in plugins in case ``xdist`` is not installed. Please see:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 import os
 from typing import Any
-from typing import Sequence
 from typing import TYPE_CHECKING
 
 import execnet

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -9,16 +9,16 @@ needs not to be installed in remote environments.
 from __future__ import annotations
 
 import collections
+from collections.abc import Generator
+from collections.abc import Iterable
+from collections.abc import Sequence
 import contextlib
 import enum
 import os
 import sys
 import time
 from typing import Any
-from typing import Generator
-from typing import Iterable
 from typing import Literal
-from typing import Sequence
 from typing import TypedDict
 from typing import Union
 import warnings
@@ -98,7 +98,7 @@ class TestQueue:
             self._items = collections.deque(iterable)
 
     @contextlib.contextmanager
-    def lock(self) -> Generator[collections.deque[Item], None, None]:
+    def lock(self) -> Generator[collections.deque[Item]]:
         with self._lock:
             try:
                 yield self._items

--- a/src/xdist/report.py
+++ b/src/xdist/report.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from difflib import unified_diff
-from typing import Sequence
 
 
 def report_collection_diff(

--- a/src/xdist/scheduler/each.py
+++ b/src/xdist/scheduler/each.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import pytest
 

--- a/src/xdist/scheduler/load.py
+++ b/src/xdist/scheduler/load.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from itertools import cycle
-from typing import Sequence
 
 import pytest
 

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from collections.abc import Sequence
 from typing import NoReturn
-from typing import Sequence
 
 import pytest
 

--- a/src/xdist/scheduler/protocol.py
+++ b/src/xdist/scheduler/protocol.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Protocol
-from typing import Sequence
 
 from xdist.workermanage import WorkerController
 

--- a/src/xdist/scheduler/worksteal.py
+++ b/src/xdist/scheduler/worksteal.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import NamedTuple
-from typing import Sequence
 
 import pytest
 

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 import enum
 import fnmatch
 import os
@@ -9,7 +10,6 @@ import sys
 from typing import Any
 from typing import Callable
 from typing import Literal
-from typing import Sequence
 from typing import Union
 import uuid
 import warnings

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Generator
 import shutil
 from typing import Callable
-from typing import Generator
 
 import execnet
 import pytest
@@ -12,7 +12,7 @@ pytest_plugins = "pytester"
 
 
 @pytest.fixture(autouse=True)
-def _divert_atexit(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+def _divert_atexit(monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
     import atexit
 
     finalizers = []

--- a/testing/test_dsession.py
+++ b/testing/test_dsession.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 from typing import cast
-from typing import Sequence
 from typing import TYPE_CHECKING
 
 import execnet

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -7,7 +7,6 @@ import sys
 from typing import Any
 from typing import Callable
 from typing import cast
-from typing import Dict
 from typing import Union
 import uuid
 
@@ -90,7 +89,7 @@ def worker(request: pytest.FixtureRequest, pytester: pytest.Pytester) -> WorkerS
 
 class TestWorkerInteractor:
     UnserializerReport = Callable[
-        [Dict[str, Any]], Union[pytest.CollectReport, pytest.TestReport]
+        [dict[str, Any]], Union[pytest.CollectReport, pytest.TestReport]
     ]
 
     @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
   linting
-  py{38,39,310,311,312,313}-pytestlatest
+  py{39,310,311,312,313}-pytestlatest
   py310-pytestmain
   py310-psutil
   py310-setproctitle


### PR DESCRIPTION
Also executed `pyupgrade --py39-plus` on all files.