### PR TITLE
Document disabling with '-n 0'

### DIFF
--- a/docs/distribution.rst
+++ b/docs/distribution.rst
@@ -19,6 +19,8 @@ if it is not or if it fails to determine the number of logical CPUs, fall back t
 
 Pass a number, e.g. ``-n 8``, to specify the number of processes explicitly.
 
+Use ``-n 0`` to disable xdist and run all tests in the main process.
+
 To specify a different meaning for ``-n auto`` and ``-n logical`` for your
 tests, you can:
 


### PR DESCRIPTION
I found that `-n 0` was not properly documented, just in this mention in the "how to" guide:

https://github.com/pytest-dev/pytest-xdist/blob/f83299cd646965ac0560adddcf7204adde9f486e/docs/how-to.rst?plain=1#L21-L22

Plus some error messages and docstrings like:

https://github.com/pytest-dev/pytest-xdist/blob/8074c633c8ff30e0c5656888ae71fd81888396f4/src/xdist/plugin.py#L305-L308

This PR makes it explicit. I don't think a changelog entry is required.

- [x] Make sure to include reasonable tests for your change if necessary

- [ ] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
