### PR TITLE
Ensure all xdist group names are strings

### DIFF
--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -248,7 +248,7 @@ class WorkerInteractor:
                         if len(mark.args) > 0
                         else mark.kwargs.get("name", "default")
                     )
-                    gnames.add(name)
+                    gnames.add(str(name))
                 if not gnames:
                     continue
                 item._nodeid = f"{item.nodeid}@{'_'.join(sorted(gnames))}"


### PR DESCRIPTION
Will come back and fill out the description. This is a possible solve of https://github.com/pytest-dev/pytest-xdist/issues/1215 for review.

The previous code before https://github.com/pytest-dev/pytest-xdist/pull/1201 called `__str__` on all group names via the f-string coercion

<!---

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [ ] Make sure to include reasonable tests for your change if necessary

- [ ] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
--->