### PR TITLE
Toan/loadscope retain ordering

### DIFF
--- a/changelog/1083.trivial
+++ b/changelog/1083.trivial
@@ -1,0 +1,1 @@
+With `--no-loadscope-reorder`, retain input ordering in loadscope for tests where relative ordering matters. i.e. guarantee that, given [input_1, input_2],input_2 never runs before input_1. On any given worker, either input_1 has ran before input_2, or input_1 has never and will never run on this worker. This only applies when using `loadscope`.

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -136,7 +136,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "Reorders tests when used in conjunction with loadscope.\n"
             "Will order tests by number of tests per scope as a best-effort"
             " attempt to evenly distribute scopes across all workers."
-        )
+        ),
     )
     group.addoption(
         "--tx",

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -128,6 +128,17 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         ),
     )
     group.addoption(
+        "--no-loadscope-reorder",
+        action="store_true",
+        dest="noloadscopenoreorder",
+        default=False,
+        help=(
+            "Reorders tests when used in conjunction with loadscope.\n"
+            "Will order tests by number of tests per scope as a best-effort"
+            " attempt to evenly distribute scopes across all workers."
+        )
+    )
+    group.addoption(
         "--tx",
         dest="tx",
         action="append",

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -371,11 +371,15 @@ class LoadScopeScheduling:
             work_unit = unsorted_workqueue.setdefault(scope, {})
             work_unit[nodeid] = False
 
-        # Insert tests scopes into work queue ordered by number of tests.
-        for scope, nodeids in sorted(
-            unsorted_workqueue.items(), key=lambda item: -len(item[1])
-        ):
-            self.workqueue[scope] = nodeids
+        if self.config.option.noloadscopenoreorder:
+            for scope, nodeids in unsorted_workqueue.items():
+                self.workqueue[scope] = nodeids
+        else:
+            # Insert tests scopes into work queue ordered by number of tests.
+            for scope, nodeids in sorted(
+                unsorted_workqueue.items(), key=lambda item: -len(item[1])
+            ):
+                self.workqueue[scope] = nodeids
 
         # Avoid having more workers than work
         extra_nodes = len(self.nodes) - len(self.workqueue)

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1262,7 +1262,9 @@ class TestLoadScope:
                 pass
         """
         pytester.makepyfile(test_a=test_file.format(10), test_b=test_file.format(20))
-        result = pytester.runpytest("-n2", "--dist=loadscope", "--no-loadscope-reorder", "-v")
+        result = pytester.runpytest(
+            "-n2", "--dist=loadscope", "--no-loadscope-reorder", "-v"
+        )
         assert get_workers_and_test_count_by_prefix(
             "test_a.py::test", result.outlines
         ) == {"gw0": 10}

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1254,6 +1254,22 @@ class TestLoadScope:
             "test_b.py::test", result.outlines
         ) == {"gw0": 20}
 
+    def test_workqueue_ordered_by_input(self, pytester: pytest.Pytester) -> None:
+        test_file = """
+            import pytest
+            @pytest.mark.parametrize('i', range({}))
+            def test(i):
+                pass
+        """
+        pytester.makepyfile(test_a=test_file.format(10), test_b=test_file.format(20))
+        result = pytester.runpytest("-n2", "--dist=loadscope", "--no-loadscope-reorder", "-v")
+        assert get_workers_and_test_count_by_prefix(
+            "test_a.py::test", result.outlines
+        ) == {"gw0": 10}
+        assert get_workers_and_test_count_by_prefix(
+            "test_b.py::test", result.outlines
+        ) == {"gw1": 20}
+
     def test_module_single_start(self, pytester: pytest.Pytester) -> None:
         """Fix test suite never finishing in case all workers start with a single test (#277)."""
         test_file1 = """


### PR DESCRIPTION
This is a pull request coming from https://github.com/pytest-dev/pytest-xdist/pull/1098 to enable the possibility to merge. 
This pull request rebase the original changes to the latest master branch commit.

I'm not the original author but would be willing to help improve the code if there is any comments

-------------------

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
