### PR TITLE
Install the wheel in tox env @ CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,4 +93,4 @@ jobs:
     - name: Test
       shell: bash
       run: |
-        tox run -e ${{ matrix.tox_env }} --installpkg `find dist/*.tar.gz`
+        tox run -e ${{ matrix.tox_env }} --installpkg "$(find dist/*.whl)"


### PR DESCRIPTION
This should be faster than having tox build it every time from sdist. Looks like this saves about 10 seconds per job.