### PR TITLE
Declare support for Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           - tox_env: "py313-pytestlatest"
             python: "3.13"
           - tox_env: "py314-pytestlatest"
-            python: "3.14"
+            python: "~3.14.0-0"
           - tox_env: "py310-psutil"
             python: "3.10"
           - tox_env: "py310-setproctitle"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
           - "py311-pytestmain"
           - "py312-pytestlatest"
           - "py313-pytestlatest"
+          - "py314-pytestlatest"
           - "py310-psutil"
           - "py310-setproctitle"
 
@@ -60,6 +61,8 @@ jobs:
             python: "3.12"
           - tox_env: "py313-pytestlatest"
             python: "3.13"
+          - tox_env: "py314-pytestlatest"
+            python: "3.14"
           - tox_env: "py310-psutil"
             python: "3.10"
           - tox_env: "py310-setproctitle"

--- a/changelog/1252.feature.rst
+++ b/changelog/1252.feature.rst
@@ -1,0 +1,1 @@
+Python 3.14 is now tested and supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">=3.9"
 dependencies = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
   linting
-  py{39,310,311,312,313}-pytestlatest
+  py{39,310,311,312,313,314}-pytestlatest
   py310-pytestmain
   py310-psutil
   py310-setproctitle


### PR DESCRIPTION
This includes integrating the corresponding envs in tests (GHA + tox) and adding a Trove classifier.