### PR TITLE
Support `-X cpu_count` and PYTHON_CPU_COUNT (#1296)

### DIFF
--- a/changelog/1296.feature.rst
+++ b/changelog/1296.feature.rst
@@ -1,0 +1,5 @@
+``-n auto`` and ``-n logical`` now support the ``PYTHON_CPU_COUNT``
+environment variable and the ``-X cpu_count`` option from Python 3.13 (but
+on all supported Python versions) to override the auto-detected CPU count.
+The ``PYTEST_XDIST_AUTO_NUM_WORKERS`` environment variable has precedence
+over these.

--- a/docs/distribution.rst
+++ b/docs/distribution.rst
@@ -14,8 +14,10 @@ With ``-n auto``, pytest-xdist will use as many processes as your computer
 has physical CPU cores.
 
 Use ``-n logical`` to use the number of *logical* CPU cores rather than
-physical ones. This currently requires the `psutil <https://pypi.org/project/psutil/>`__ package to be installed;
-if it is not or if it fails to determine the number of logical CPUs, fall back to ``-n auto`` behavior.
+physical ones. This currently requires either Python 3.13 or higher, or the
+`psutil <https://pypi.org/project/psutil/>`__ package to be installed. If
+neither method is available or if they all fail to determine the number of
+logical CPUs, fall back to ``-n auto`` behavior.
 
 Pass a number, e.g. ``-n 8``, to specify the number of processes explicitly.
 
@@ -25,7 +27,12 @@ To specify a different meaning for ``-n auto`` and ``-n logical`` for your
 tests, you can:
 
 * Set the environment variable ``PYTEST_XDIST_AUTO_NUM_WORKERS`` to the
-  desired number of processes.
+  desired number of processes. This is specific to xdist.
+
+  Alternatively, use the standard ``-X cpu_count`` option to the Python
+  interpreter or set the environment variable ``PYTHON_CPU_COUNT`` to affect
+  the entire Python process, as documented for Python 3.13. xdist honors
+  these settings even on Python 3.12 and lower.
 
 * Implement the ``pytest_xdist_auto_num_workers``
   `pytest hook <https://docs.pytest.org/en/latest/how-to/writing_plugins.html>`__
@@ -35,8 +42,10 @@ tests, you can:
   asked for ``"auto"`` or ``"logical"``, and it can return ``None`` to fall
   back to the default.
 
-If both the hook and environment variable are specified, the hook takes
-priority.
+If both the hook and overrides are specified, the hook takes priority over
+the ``PYTEST_XDIST_AUTO_NUM_WORKERS`` environment variable, which in turn
+takes priority over the ``-X cpu_count`` option, which in turn takes
+priority over the ``PYTHON_CPU_COUNT`` environment variable.
 
 
 Parallelization can be configured further with these options:

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -2,27 +2,34 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Literal
+from typing import TYPE_CHECKING
 import uuid
 import warnings
 
 import pytest
 
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Literal
+
+
 _sys_path = list(sys.path)  # freeze a copy of sys.path at interpreter startup
 
 
-@pytest.hookimpl
-def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
-    env_var = os.environ.get("PYTEST_XDIST_AUTO_NUM_WORKERS")
-    if env_var:
-        try:
+def _auto_num_workers_envvar(config: pytest.Config) -> int | None:
+    try:
+        env_var = os.environ.get("PYTEST_XDIST_AUTO_NUM_WORKERS")
+        if env_var is not None:
             return int(env_var)
-        except ValueError:
-            warnings.warn(
-                "PYTEST_XDIST_AUTO_NUM_WORKERS is not a number: {env_var!r}. Ignoring it."
-            )
+    except ValueError:
+        warnings.warn(
+            "PYTEST_XDIST_AUTO_NUM_WORKERS is not a number: {env_var!r}. Ignoring it."
+        )
+    return None
 
+
+def _auto_num_workers_x_option_python_cpu_count(config: pytest.Config) -> int | None:
     # New in Python 3.13, but the mechanisms are available since 3.2. Per
     # https://github.com/python/cpython/issues/109595#issuecomment-1731240132,
     # the -X option overrides the environment variable.
@@ -43,56 +50,88 @@ def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
                 )
     else:
         env_var = os.environ.get("PYTHON_CPU_COUNT")
-        if env_var:
+        if env_var is not None:
             try:
                 return int(env_var)
             except ValueError:
                 warnings.warn(
                     "PYTHON_CPU_COUNT is not a number: {env_var!r}. Ignoring it."
                 )
+    return None
 
-    count: int | None
-    if config.option.numprocesses == "logical":
-        # New in Python 3.13.
-        try:
-            from os import (
-                process_cpu_count,  # type: ignore[attr-defined, unused-ignore]
-            )
-        except ImportError:
-            pass
+
+def _auto_num_workers_os_process_cpu_count(config: pytest.Config) -> int | None:
+    if config.option.numprocesses != "logical":
+        return None
+    # New in Python 3.13.
+    try:
+        if TYPE_CHECKING:  # type-check also on older Pythons
+            process_cpu_count: Callable[[], int | None]
         else:
-            count = process_cpu_count()
-            if count:
-                return count
+            from os import process_cpu_count
+    except ImportError:
+        return None
+    else:
+        count = process_cpu_count()
+        if count:
+            return count
+        return None
 
+
+def _auto_num_workers_psutil(config: pytest.Config) -> int | None:
     try:
         import psutil
     except ImportError:
-        pass
+        return None
     else:
         use_logical: bool = config.option.numprocesses == "logical"
         count = psutil.cpu_count(logical=use_logical) or psutil.cpu_count()
         if count:
             return count
+        return None
+
+
+def _auto_num_workers_os_sched_getaffinity(config: pytest.Config) -> int | None:
     try:
         from os import sched_getaffinity
 
-        def cpu_count() -> int:
-            return len(sched_getaffinity(0))
-
+        return len(sched_getaffinity(0))
     except ImportError:
         if os.environ.get("TRAVIS") == "true":
             # workaround https://github.com/pypy/pypy/issues/2375
             return 2
-        try:
-            from os import cpu_count  # type: ignore[assignment]
-        except ImportError:
-            from multiprocessing import cpu_count
+        return None
+
+
+def _auto_num_workers_os_multiprocessing_cpu_count(config: pytest.Config) -> int | None:
+    try:
+        from os import cpu_count
+    except ImportError:
+        from multiprocessing import cpu_count
     try:
         n = cpu_count()
     except NotImplementedError:
-        return 1
-    return n if n else 1
+        return None
+    if n:
+        return n
+    return None
+
+
+@pytest.hookimpl
+def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
+    providers: list[Callable[[pytest.Config], int | None]] = [
+        _auto_num_workers_envvar,
+        _auto_num_workers_x_option_python_cpu_count,
+        _auto_num_workers_os_process_cpu_count,
+        _auto_num_workers_psutil,
+        _auto_num_workers_os_sched_getaffinity,
+        _auto_num_workers_os_multiprocessing_cpu_count,
+    ]
+    for provider in providers:
+        result = provider(config)
+        if result is not None:
+            return result
+    return 1
 
 
 def parse_numprocesses(s: str) -> int | Literal["auto", "logical"]:

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -55,7 +55,9 @@ def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
     if config.option.numprocesses == "logical":
         # New in Python 3.13.
         try:
-            from os import process_cpu_count
+            from os import (
+                process_cpu_count,  # type: ignore[attr-defined, unused-ignore]
+            )
         except ImportError:
             pass
         else:


### PR DESCRIPTION
Support `-X cpu_count` and `PYTHON_CPU_COUNT` in the `pytest_xdist_auto_num_workers` hook, on all Python versions. The `PYTEST_XDIST_AUTO_NUM_WORKERS` environment variable overrides `-X cpu_count`, which in turn overrides `PYTHON_CPU_COUNT`, which in turn inhibits querying `psutil`.

On Python 3.13, also support the `os.process_cpu_count` function in case `-n logical` is requested. This overrides querying `psutil`, and is in turn overridden by `PYTHON_CPU_COUNT`.

Fixes #1296

---

Open questions:

- As of Python 3.13, the documentation for `os.cpu_count` and `os.process_cpu_count` only speaks of logical CPUs. Should the xdist documentation (or even the implementation?) similarly retire the distinction between physical and logical CPUs?
- Should the documentation prominently mention the xdist version from which the behavior change (`-X` option/`PYTHON_CPU_COUNT`) is available?

Other feedback wanted:

- Is the "mood" of the documentation (and commentary, and changelog entry, etc.) correct? There was no concrete guidance, so I'm going by whatever I think is sensible…

---

Checklist:

- [x] Make sure to include reasonable tests for your change if necessary

- [x] We use [towncrier](https://pypi.org/project/towncrier) for changelog management, so please add a *news* file into the `changelog` folder following these guidelines:
  * Name it `$issue_id.$type` for example `588.bugfix`;
  * If you don't have an issue_id change it to the PR id after creating it
  * Ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example:

    ```
    Fix issue with non-ascii contents in doctest text files.
    ```
