### PR TITLE
fix: ensure consistent node workload assignment by sorting nodes by gwid

### DIFF
--- a/changelog/985.bugfix.rst
+++ b/changelog/985.bugfix.rst
@@ -1,0 +1,1 @@
+De-flaked test_workqueue_ordered_by_size.

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -394,11 +394,12 @@ class LoadScopeScheduling:
                 unused_node.shutdown()
 
         # Assign initial workload
-        for node in self.nodes:
+        # Sort the nodes to keep assingment consistent (#985)
+        for node in sorted(self.nodes, key=lambda node: node.gateway.id):
             self._assign_work_unit(node)
 
         # Ensure nodes start with at least two work units if possible (#277)
-        for node in self.nodes:
+        for node in sorted(self.nodes, key=lambda node: node.gateway.id):
             self._reschedule(node)
 
         # Initial distribution sent all tests, start node shutdown


### PR DESCRIPTION
Fixes the flaky test_workqueue_ordered_by_size test (#985 and #1248 )

Here's a quick checklist that should be present in PRs:

- [x] Make sure to include reasonable tests for your change if necessary
- [x] We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder.