### PR TITLE
Fix hang with `--dist=loadgroup` if a crashed worker is replaced and there is still work to be done

### DIFF
--- a/changelog/1327.bugfix.rst
+++ b/changelog/1327.bugfix.rst
@@ -1,0 +1,1 @@
+Fix hang with `--dist=loadgroup` if a crashed worker is replaced.

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -352,6 +352,12 @@ class LoadScopeScheduling:
         if self.collection is not None:
             for node in self.nodes:
                 self._reschedule(node)
+            # Ensure nodes have at least two work units if possible,
+            # since workers need a "next item" before running the current one.
+            # (A restarted worker has no item before calling _reschedule()
+            # for the first time.)
+            for node in self.nodes:
+                self._reschedule(node)
             return
 
         # Check that all nodes collected the same tests

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -360,6 +360,12 @@ class LoadScopeScheduling:
         if self.collection is not None:
             for node in self.nodes:
                 self._reschedule(node)
+            # Ensure nodes have at least two work units if possible,
+            # since workers need a "next item" before running the current one.
+            # (A restarted worker has no item before calling _reschedule()
+            # for the first time.)
+            for node in self.nodes:
+                self._reschedule(node)
             return
 
         # Check that all nodes collected the same tests

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -974,6 +974,27 @@ class TestNodeFailure:
             ]
         )
 
+    def test_loadgroup_does_not_hang_after_restart2(
+        self, pytester: pytest.Pytester
+    ) -> None:
+        """Fix test suite never finishing in case a worker has to be restarted
+        if there is still work to be done (#1327)."""
+        f = pytester.makepyfile(
+            """
+            import os
+            def test_a(): os._exit(1)
+            def test_b(): pass
+        """
+        )
+        res = pytester.runpytest(f, "-n1", "--dist=loadgroup")
+        res.stdout.fnmatch_lines(
+            [
+                "replacing crashed worker gw*",
+                "worker*crashed while running*",
+                "*5 failed*",
+            ]
+        )
+
     def test_max_worker_restart(self, pytester: pytest.Pytester) -> None:
         f = pytester.makepyfile(
             """

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1011,6 +1011,27 @@ class TestNodeFailure:
             ]
         )
 
+    def test_loadgroup_does_not_hang_after_restart2(
+        self, pytester: pytest.Pytester
+    ) -> None:
+        """Fix test suite never finishing in case a worker has to be restarted
+        if there is still work to be done (#1327)."""
+        f = pytester.makepyfile(
+            """
+            import os
+            def test_a(): os._exit(1)
+            def test_b(): pass
+        """
+        )
+        res = pytester.runpytest(f, "-n1", "--dist=loadgroup")
+        res.stdout.fnmatch_lines(
+            [
+                "replacing crashed worker gw*",
+                "worker*crashed while running*",
+                "*5 failed*",
+            ]
+        )
+
     def test_max_worker_restart(self, pytester: pytest.Pytester) -> None:
         f = pytester.makepyfile(
             """


### PR DESCRIPTION
Resolves #1327