### PR TITLE
docs: document multiprocessing fork warning workaround for #1186

### DIFF
--- a/changelog/1186.doc.rst
+++ b/changelog/1186.doc.rst
@@ -1,0 +1,1 @@
+Document the recommended ``multiprocessing`` ``spawn`` context workaround for the fork warning emitted when tests call ``os.fork()`` under xdist.

--- a/docs/known-limitations.rst
+++ b/docs/known-limitations.rst
@@ -69,3 +69,27 @@ Debugging
 This also means that debugging using PDB (or any other debugger that wants to use standard I/O) will not work. The ``--pdb`` option is disabled when distributing tests with ``pytest-xdist`` for this reason.
 
 It is generally likely best to use ``pytest-xdist`` to find failing tests and then debug them without distribution; however, if you need to debug from within a worker process (for example, to address failures that only happen when running tests concurrently), remote debuggers (for example, `python-remote-pdb <https://github.com/ionelmc/python-remote-pdb>`__ or `python-web-pdb <https://github.com/romanvm/python-web-pdb>`__) have been reported to work for this purpose.
+
+.. _multiprocessing-fork-warning:
+
+Warnings when tests use ``multiprocessing`` with ``fork``
+---------------------------------------------------------
+
+When a test running under xdist invokes ``multiprocessing.get_context("fork")`` or relies on the default fork start method on Linux, you may see a warning about creating a child process from a non-main thread, even though your test itself runs on the main thread of the xdist worker.
+
+This is a known interaction with the threading primitives used by `execnet <https://github.com/pytest-dev/execnet>`__, which xdist depends on for worker communication. See issue `#1186 <https://github.com/pytest-dev/pytest-xdist/issues/1186>`__ for the background and `execnet#336 <https://github.com/pytest-dev/execnet/pull/336>`__ for the upstream structural fix that is being investigated.
+
+Recommended workaround: switch the multiprocessing context to ``spawn`` for processes that are created inside the test:
+
+.. code-block:: python
+
+    import multiprocessing
+
+
+    def test_thing():
+        ctx = multiprocessing.get_context("spawn")
+        proc = ctx.Process(target=worker, args=())
+        proc.start()
+        proc.join()
+
+``spawn`` does not inherit the parent's thread state, so the warning does not fire. It is also the default on Windows and macOS already, so this only changes behaviour on Linux.


### PR DESCRIPTION
This adds a short docs section explaining the multiprocessing fork warning that surfaces in #1186 and pointing readers at the spawn-context workaround that @RonnyPfannschmidt has suggested in the thread.

The intent is to make the workaround discoverable from the project docs rather than only from the issue comments, while the upstream execnet#336 experiment is still in progress. Once that lands and the warning stops appearing for the fork case, this section can either be trimmed to a note about historical 3.x behaviour or removed entirely.

Closes nothing. The issue should stay open until the execnet-side fix lands.

Links:
- Issue: https://github.com/pytest-dev/pytest-xdist/issues/1186
- Upstream fix in flight: https://github.com/pytest-dev/execnet/pull/336

The new section is added at the end of docs/known-limitations.rst since that page already lists xdist quirks with workarounds. If you would prefer it under a different page (e.g. a future FAQ), let me know and I will move it.
