### PR TITLE
fix: stop worker when shouldfail/shouldstop is set (--exitfirst / --maxfail)

### DIFF
--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -205,6 +205,10 @@ class WorkerInteractor:
         self.channel.setcallback(self.handle_command, endmarker=Marker.SHUTDOWN)
         self.nextitem_index = self.torun.get()
         while self.nextitem_index is not Marker.SHUTDOWN:
+            # Check shouldfail/shouldstop before running the pre-fetched test,
+            # in case it was set during the previous test's execution
+            if session.shouldfail or session.shouldstop:
+                break
             self.run_one_test()
             if session.shouldfail or session.shouldstop:
                 break
@@ -235,6 +239,12 @@ class WorkerInteractor:
         self.sendevent(
             "runtest_protocol_complete", item_index=self.item_index, duration=duration
         )
+
+        # If shouldfail/shouldstop was set during test execution, ensure the
+        # nextitem_index causes an immediate loop exit. This prevents the
+        # pre-fetched next test from running after the session should stop.
+        if self.session.shouldfail or self.session.shouldstop:
+            self.nextitem_index = Marker.SHUTDOWN
 
     def _sleep_before_first_test(self) -> None:
         if self._ramp_sleep_done:

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -210,8 +210,6 @@ class WorkerInteractor:
             if session.shouldfail or session.shouldstop:
                 break
             self.run_one_test()
-            if session.shouldfail or session.shouldstop:
-                break
         return True
 
     def run_one_test(self) -> None:

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -47,11 +47,11 @@ class WorkerSetup:
         self.use_callback = False
         self.events = Queue()  # type: ignore[var-annotated]
 
-    def setup(self) -> None:
+    def setup(self, extra_args: tuple[str, ...] = ()) -> None:
         self.pytester.chdir()
         # import os ; os.environ['EXECNET_DEBUG'] = "2"
         self.gateway = execnet.makegateway("execmodel=main_thread_only//popen")
-        self.config = config = self.pytester.parseconfigure()
+        self.config = config = self.pytester.parseconfigure(*extra_args)
         putevent = self.events.put if self.use_callback else None
 
         class DummyMananger:
@@ -270,6 +270,56 @@ class TestWorkerInteractor:
         assert "INTERNALERROR> ValueError: unknown event: <nonono>" in out
         ev = worker.popevent()
         assert ev.name == "errordown"
+
+    def test_early_shutdown_stops_worker_after_local_failure(
+        self, worker: WorkerSetup, unserialize_report: UnserializerReport
+    ) -> None:
+        """When a test fails and shouldfail is set (as happens with --exitfirst),
+        the worker should stop immediately and NOT run the pre-fetched next test.
+
+        This verifies the fix for issues #420, #868, and #1034 where
+        --exitfirst/--maxfail would let the failing worker continue running
+        tests in the background.
+        """
+        worker.pytester.makepyfile(
+            """
+            def test_pass():
+                pass
+            def test_fail():
+                assert False, "intentional failure"
+            def test_should_not_run():
+                pass
+        """
+        )
+        worker.setup(("-x",))  # Pass --exitfirst so maxfail=1
+        # Setup phase
+        ev = worker.popevent()
+        assert ev.name == "workerready"
+        ev = worker.popevent()
+        assert ev.name == "collectionstart"
+        ev = worker.popevent("collectionfinish")
+        ids = ev.kwargs["ids"]
+        assert len(ids) == 3
+        # Send all tests, wait for the first one to run and complete
+        worker.sendcommand("runtests_all")
+        ev = worker.popevent("logstart")
+        assert ev.kwargs["nodeid"].endswith("test_pass")
+        # test_pass should complete (setup + call + teardown = 3 reports)
+        for _ in range(3):
+            ev = worker.popevent("testreport")
+            assert ev.name == "testreport"
+        # test_fail should start
+        ev = worker.popevent("logstart")
+        assert ev.kwargs["nodeid"].endswith("test_fail")
+        # test_fail runs and fails. pytest's session sets shouldfail.
+        # The worker should then stop without running test_should_not_run.
+        # We check that workerfinished arrives without test_should_not_run
+        # having been logged.
+        ev = worker.popevent("workerfinished")
+        assert "workeroutput" in ev.kwargs
+        wo = ev.kwargs["workeroutput"]
+        assert wo["exitstatus"] == 1  # at least one test failed
+        assert wo["shouldfail"]  # shouldfail should be set by pytest
 
     def test_steal_work(
         self, worker: WorkerSetup, unserialize_report: UnserializerReport


### PR DESCRIPTION
The `--exitfirst` / `--maxfail` flags don't stop workers promptly when a test fails. The failing worker keeps running — it executes the next pre-fetched test before checking `shouldfail`.

Turns out the issue is in the worker's main loop: `torun.get()` pre-fetches the NEXT test before the current one finishes. When the current test fails, `session.shouldfail` gets set by pytest's runner. But `run_one_test` already moved on — the pre-fetched item is about to execute and the `shouldfail` check after `run_one_test` comes too late.

Noticed this while looking at #420 (open since 2019), #868, and #1034 — they all point to the same underlying thing.

**What this does:**

1. Checks `shouldfail`/`shouldstop` **before** `run_one_test` in the while loop, so a locally-set flag from the previous iteration is caught
2. After `runtest_protocol_complete`, if `shouldfail`/`shouldstop` is truthy, overrides `nextitem_index` to `Marker.SHUTDOWN` — this makes the loop exit cleanly without running the already-fetched next item

With `-x` set, the worker that hits a failure now stops right after the failing test instead of running one more.

Happy to adjust the approach if there's a better place to hook this.
