### PR TITLE
Fix CLI options ignored when --looponfail runs with -n (#767)

### DIFF
--- a/changelog/767.bugfix.rst
+++ b/changelog/767.bugfix.rst
@@ -1,0 +1,5 @@
+Command-line options such as ``--tb=short`` are no longer dropped when
+``--looponfail`` is combined with distributed runs (``-n``). Previously the
+worker session was rebuilt only from the parsed options and positional
+arguments, so the original invocation flags were lost and the nested workers
+fell back to their defaults (for example, the long traceback style).

--- a/src/xdist/looponfail.py
+++ b/src/xdist/looponfail.py
@@ -164,7 +164,6 @@ def init_worker_session(
     option_dict: dict[str, "Any"],  # noqa: UP037
     invocation_args: list[str],
 ) -> None:
-    import dataclasses
     import os
     import sys
 
@@ -191,8 +190,16 @@ def init_worker_session(
     # original command-line flags (e.g. --tb=short). Restore the full
     # invocation arguments so that any nested distributed (-n) run propagates
     # those options to its workers. See #767.
-    config.invocation_params = dataclasses.replace(
-        config.invocation_params, args=tuple(invocation_args)
+    #
+    # InvocationParams is constructed directly (rather than via
+    # dataclasses.replace) because it is a frozen attrs class on pytest 7.x
+    # and a dataclass only on newer pytest; calling its type with the same
+    # fields works across both.
+    invocation_params = config.invocation_params
+    config.invocation_params = type(invocation_params)(
+        args=tuple(invocation_args),
+        plugins=invocation_params.plugins,
+        dir=invocation_params.dir,
     )
     from xdist.looponfail import WorkerFailSession
 

--- a/src/xdist/looponfail.py
+++ b/src/xdist/looponfail.py
@@ -93,6 +93,7 @@ class RemoteControl:
             init_worker_session,
             args=self.config.args,
             option_dict=vars(self.config.option),
+            invocation_args=list(self.config.invocation_params.args),
         )
         remote_outchannel: execnet.Channel = channel.receive()
 
@@ -161,7 +162,9 @@ def init_worker_session(
     channel: "execnet.Channel",  # noqa: UP037
     args: list[str],
     option_dict: dict[str, "Any"],  # noqa: UP037
+    invocation_args: list[str],
 ) -> None:
+    import dataclasses
     import os
     import sys
 
@@ -183,6 +186,14 @@ def init_worker_session(
 
     config = Config.fromdictargs(option_dict, list(args))
     config.args = args
+    # fromdictargs() rebuilds the config from the parsed options plus the
+    # positional arguments only, so config.invocation_params.args loses the
+    # original command-line flags (e.g. --tb=short). Restore the full
+    # invocation arguments so that any nested distributed (-n) run propagates
+    # those options to its workers. See #767.
+    config.invocation_params = dataclasses.replace(
+        config.invocation_params, args=tuple(invocation_args)
+    )
     from xdist.looponfail import WorkerFailSession
 
     WorkerFailSession(config, channel).main()

--- a/testing/test_looponfail.py
+++ b/testing/test_looponfail.py
@@ -342,6 +342,50 @@ class TestLooponFailing:
         remotecontrol.loop_once()
         assert len(remotecontrol.failures) == 1
 
+    def test_looponfail_passes_command_line_options_to_workers(
+        self,
+        pytester: pytest.Pytester,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Regression test for #767: command-line options such as --tb=short
+        # were dropped when looponfail ran the failing tests through
+        # distributed (-n) workers. The reconstructed worker config lost the
+        # original invocation arguments, so the nested workers fell back to
+        # the default (long) traceback style.
+        pytester.makepyfile(
+            foo=textwrap.dedent(
+                """
+                def a():
+                    b()
+
+                def b():
+                    c()
+
+                def c():
+                    assert False
+                """
+            )
+        )
+        modcol = pytester.getmodulecol(
+            textwrap.dedent(
+                """
+                from foo import a
+
+                def test_foo():
+                    a()
+                """
+            ),
+            configargs=["-n2", "--tb=short"],
+        )
+        control = RemoteControl(modcol.config)
+        control.loop_once()
+        out, _err = capsys.readouterr()
+        # --tb=short renders frames as compact "path:lineno: in func" lines.
+        # The default (long) style instead expands the source ("def test_foo():"
+        # with a ">" marker), so its absence confirms the option propagated.
+        assert ": in test_foo" in out
+        assert "def test_foo():" not in out
+
 
 class TestFunctional:
     def test_fail_to_ok(self, pytester: pytest.Pytester) -> None:


### PR DESCRIPTION
Fixes #767.

## Problem

`pytest --tb=short -n2 --looponfail` ignores `--tb=short` and prints a long traceback. The option is only dropped when `--looponfail` and `-n` are combined; each on its own respects `--tb=short`.

## Root cause

`--looponfail` rebuilds the worker session config via `Config.fromdictargs(option_dict, args)`, where `args` is the positional test paths only. `fromdictargs` sets `config.invocation_params.args` to exactly those positional arguments, so the original command-line flags (e.g. `--tb=short`) are not present there, even though `config.option` carries them.

That is fine for looponfail's own in-process run, which reads `config.option` directly. But when looponfail runs a nested distributed (`-n`) session, `WorkerController.setup` builds the nested worker argv from `config.invocation_params.args` (workermanage.py). Since the flags are missing there, the nested workers fall back to their defaults, including the long traceback style.

## Fix

Pass the original invocation arguments to the looponfail worker and restore a faithful `config.invocation_params.args` after `fromdictargs`. This propagates all command-line flags (not just `--tb`) to nested workers. `dataclasses.replace` is used because `InvocationParams` is a frozen dataclass; `plugins` and `dir` are preserved.

## Tests

Added a regression test in `testing/test_looponfail.py` that runs the failing tests through `RemoteControl.loop_once()` with `-n2 --tb=short` and asserts the short-style traceback markers appear (and the long-style source expansion does not).

Verified locally:
- New test fails without the fix, passes with it.
- Full `testing/test_looponfail.py` passes (no regressions).
- `ruff check`, `ruff format --check`, and `mypy` are clean.
- The original reproduction command from the issue now prints a short traceback.