### PR TITLE
Propagate worker usage errors to controller

### DIFF
--- a/changelog/109.bugfix.rst
+++ b/changelog/109.bugfix.rst
@@ -1,0 +1,3 @@
+Propagate usage errors raised during worker collection, such as missing requested
+paths, back to the controller so pytest reports the original error message and
+exit code.

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -206,6 +206,17 @@ class DSession:
         workerready before shutdown was triggered.
         """
         self.config.hook.pytest_testnodedown(node=node, error=None)
+        if node.workeroutput["exitstatus"] == int(pytest.ExitCode.USAGE_ERROR):
+            self._active_nodes.remove(node)
+            if not self.shuttingdown:
+                self.triggershutdown()
+
+            usage_error = node.workeroutput.get("usage_error")
+            if usage_error:
+                raise pytest.UsageError(*usage_error)
+
+            raise pytest.UsageError(f"{node} exited with a usage error")
+
         if node.workeroutput["exitstatus"] == 2:  # keyboard-interrupt
             self.shouldstop = f"{node} received keyboard-interrupt"
             self.worker_errordown(node, "keyboard-interrupt")

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -150,9 +150,16 @@ class WorkerInteractor:
         yield
         self.sendevent("workerfinished", workeroutput=workeroutput)
 
-    @pytest.hookimpl
-    def pytest_collection(self) -> None:
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_collection(self) -> Generator[None, object, None]:
         self.sendevent("collectionstart")
+        outcome: Any = yield
+        if outcome.excinfo is not None and isinstance(
+            outcome.excinfo[1], pytest.UsageError
+        ):
+            exc = outcome.excinfo[1]
+            workeroutput: dict[str, Any] = self.config.workeroutput  # type: ignore[attr-defined]
+            workeroutput["usage_error"] = tuple(str(arg) for arg in exc.args)
 
     def handle_command(
         self, command: tuple[str, dict[str, Any]] | Literal[Marker.SHUTDOWN]

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -77,6 +77,12 @@ class TestDistribution:
         result2 = pytester.runpytest(p1, "-n1")
         assert len(result1.stdout.lines) == len(result2.stdout.lines)
 
+    def test_missing_path_usage_error(self, pytester: pytest.Pytester) -> None:
+        result = pytester.runpytest("-n2", "MISSING")
+
+        assert result.ret == pytest.ExitCode.USAGE_ERROR
+        result.stderr.fnmatch_lines(["ERROR: file or directory not found: MISSING"])
+
     def test_n1_skip(self, pytester: pytest.Pytester) -> None:
         p1 = pytester.makepyfile(
             """


### PR DESCRIPTION
Fixes #109.

When collection on a worker raises `pytest.UsageError` (for example because a requested path does not exist), the worker exits with status 4 but the controller currently only sees an empty collection and finishes as "no tests ran" with exit code 5.

This stores the original `UsageError` arguments on the worker output during collection, then has the controller re-raise `pytest.UsageError` when a worker finishes with `ExitCode.USAGE_ERROR`. That lets pytest print the original error message and preserve the usage-error exit code.

Validation:

- `python -m pytest -p no:twisted testing\acceptance_test.py::TestDistribution::test_missing_path_usage_error -q`
- `python -m pytest -p no:twisted testing\acceptance_test.py::TestDistribution -q`
- `python -m pytest -p no:twisted testing\test_remote.py -q`
- `python -m ruff check src\xdist\remote.py src\xdist\dsession.py testing\acceptance_test.py`
- `python -m ruff format --check src\xdist\remote.py src\xdist\dsession.py testing\acceptance_test.py`
- `python -m mypy --ignore-missing-imports src\xdist\remote.py src\xdist\dsession.py testing\acceptance_test.py`

I also manually verified `python -m pytest -n2 MISSING` now returns 4 and prints `ERROR: file or directory not found: MISSING`. A full local `python -m pytest -p no:twisted -q` run was attempted but exceeded 5 minutes before completing in this environment.