### PR TITLE
Handle pytest.exit from workers

### DIFF
--- a/changelog/1239.bugfix.rst
+++ b/changelog/1239.bugfix.rst
@@ -1,0 +1,1 @@
+Handle ``pytest.exit()`` raised in a worker without reporting it as an internal error.

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -59,6 +59,7 @@ class DSession:
         self._active_nodes: set[WorkerController] = set()
         self._failed_nodes_count = 0
         self._max_worker_restart = get_default_max_worker_restart(self.config)
+        self._worker_exit: tuple[str, int | None] | None = None
         # summary message to print at the end of the session
         self._summary_report: str | None = None
         self.terminal = config.pluginmanager.getplugin("terminalreporter")
@@ -140,12 +141,16 @@ class DSession:
         assert self.sched is not None
 
         self.shouldstop = False
-        pending_exception = None
+        pending_exception: BaseException | None = None
         while not self.session_finished:
             self.loop_once()
             if self.shouldstop:
                 self.triggershutdown()
                 pending_exception = Interrupted(str(self.shouldstop))
+            if self._worker_exit is not None:
+                reason, returncode = self._worker_exit
+                self.triggershutdown()
+                pending_exception = pytest.exit.Exception(reason, returncode)
         if pending_exception:
             raise pending_exception
         return True
@@ -206,6 +211,17 @@ class DSession:
         workerready before shutdown was triggered.
         """
         self.config.hook.pytest_testnodedown(node=node, error=None)
+        if "exitreason" in node.workeroutput:
+            assert self.sched is not None
+            if node in self.sched.nodes:
+                self.sched.remove_node(node)
+            self._worker_exit = (
+                node.workeroutput["exitreason"],
+                node.workeroutput["exitreturncode"],
+            )
+            self._active_nodes.remove(node)
+            return
+
         if node.workeroutput["exitstatus"] == 2:  # keyboard-interrupt
             self.shouldstop = f"{node} received keyboard-interrupt"
             self.worker_errordown(node, "keyboard-interrupt")

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -135,6 +135,13 @@ class WorkerInteractor:
         interactor.sendevent("internal_error", formatted_error=formatted_error)
 
     @pytest.hookimpl
+    def pytest_keyboard_interrupt(self, excinfo: pytest.ExceptionInfo[BaseException]) -> None:
+        if isinstance(excinfo.value, pytest.exit.Exception):
+            workeroutput: dict[str, Any] = self.config.workeroutput  # type: ignore[attr-defined]
+            workeroutput["exitreturncode"] = excinfo.value.returncode
+            workeroutput["exitreason"] = excinfo.value.msg
+
+    @pytest.hookimpl
     def pytest_sessionstart(self, session: pytest.Session) -> None:
         self.session = session
         workerinfo = getinfodict()

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -135,7 +135,9 @@ class WorkerInteractor:
         interactor.sendevent("internal_error", formatted_error=formatted_error)
 
     @pytest.hookimpl
-    def pytest_keyboard_interrupt(self, excinfo: pytest.ExceptionInfo[BaseException]) -> None:
+    def pytest_keyboard_interrupt(
+        self, excinfo: pytest.ExceptionInfo[BaseException]
+    ) -> None:
         if isinstance(excinfo.value, pytest.exit.Exception):
             workeroutput: dict[str, Any] = self.config.workeroutput  # type: ignore[attr-defined]
             workeroutput["exitreturncode"] = excinfo.value.returncode

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -919,6 +919,28 @@ class TestWarnings:
 
 
 class TestNodeFailure:
+    @pytest.mark.parametrize("returncode", [0, 1])
+    def test_pytest_exit_is_not_reported_as_internal_error(
+        self, pytester: pytest.Pytester, returncode: int
+    ) -> None:
+        f = pytester.makepyfile(
+            f"""
+            import time
+            import pytest
+
+            @pytest.mark.parametrize("i", range(20))
+            def test_me(i):
+                if i == 12:
+                    pytest.exit("Something", {returncode})
+                time.sleep(0.01)
+        """
+        )
+        res = pytester.runpytest(f, "-n4")
+        assert res.ret == returncode
+        assert "INTERNALERROR" not in res.stdout.str()
+        assert "received keyboard-interrupt" not in res.stdout.str()
+        res.stdout.fnmatch_lines(["* _pytest.outcomes.Exit: Something *"])
+
     def test_load_single(self, pytester: pytest.Pytester) -> None:
         f = pytester.makepyfile(
             """


### PR DESCRIPTION
## Summary

- propagate `pytest.exit()` details from workers to the controller process
- stop treating a worker that exits via `pytest.exit()` as a crashed worker with a pending crash item
- re-raise pytest's `Exit` in the controller so the requested return code is preserved
- add coverage for return codes 0 and 1

Closes #1239

## Tests

- `uv run --python 3.11 --with '.[testing]' pytest testing/acceptance_test.py::TestNodeFailure::test_pytest_exit_is_not_reported_as_internal_error -q`
- `uv run --python 3.11 --with '.[testing]' pytest testing -q`
- `uv run --python 3.11 --with '.[testing]' --with ruff ruff check src/xdist/dsession.py src/xdist/remote.py testing/acceptance_test.py`
- `uv run --python 3.11 --with '.[testing]' --with mypy --with setproctitle mypy src/xdist/dsession.py src/xdist/remote.py testing/acceptance_test.py`
- `git diff --check`