### PR TITLE
Fix: Handle pytest.exit() from workers gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ pytestdebug.log
 .pytest_cache/
 .eggs/
 .idea/
+venv/

--- a/changelog/1239.bugfix.rst
+++ b/changelog/1239.bugfix.rst
@@ -1,0 +1,1 @@
+Handle ``pytest.exit()`` raised in a worker without reporting it as an internal error.

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -59,6 +59,7 @@ class DSession:
         self._active_nodes: set[WorkerController] = set()
         self._failed_nodes_count = 0
         self._max_worker_restart = get_default_max_worker_restart(self.config)
+        self._worker_exit: tuple[str, int | None] | None = None
         # summary message to print at the end of the session
         self._summary_report: str | None = None
         self.terminal = config.pluginmanager.getplugin("terminalreporter")
@@ -140,12 +141,16 @@ class DSession:
         assert self.sched is not None
 
         self.shouldstop = False
-        pending_exception = None
+        pending_exception: BaseException | None = None
         while not self.session_finished:
             self.loop_once()
             if self.shouldstop:
                 self.triggershutdown()
                 pending_exception = Interrupted(str(self.shouldstop))
+            if self._worker_exit is not None:
+                reason, returncode = self._worker_exit
+                self.triggershutdown()
+                pending_exception = pytest.exit.Exception(reason, returncode)
         if pending_exception:
             raise pending_exception
         return True
@@ -206,6 +211,17 @@ class DSession:
         workerready before shutdown was triggered.
         """
         self.config.hook.pytest_testnodedown(node=node, error=None)
+        if "exitreason" in node.workeroutput:
+            assert self.sched is not None
+            if node in self.sched.nodes:
+                self.sched.remove_node(node)
+            self._worker_exit = (
+                node.workeroutput["exitreason"],
+                node.workeroutput["exitreturncode"],
+            )
+            self._active_nodes.remove(node)
+            return
+
         if node.workeroutput["exitstatus"] == 2:  # keyboard-interrupt
             self.shouldstop = f"{node} received keyboard-interrupt"
             self.worker_errordown(node, "keyboard-interrupt")

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -135,6 +135,15 @@ class WorkerInteractor:
         interactor.sendevent("internal_error", formatted_error=formatted_error)
 
     @pytest.hookimpl
+    def pytest_keyboard_interrupt(
+        self, excinfo: pytest.ExceptionInfo[BaseException]
+    ) -> None:
+        if isinstance(excinfo.value, pytest.exit.Exception):
+            workeroutput: dict[str, Any] = self.config.workeroutput  # type: ignore[attr-defined]
+            workeroutput["exitreturncode"] = excinfo.value.returncode
+            workeroutput["exitreason"] = excinfo.value.msg
+
+    @pytest.hookimpl
     def pytest_sessionstart(self, session: pytest.Session) -> None:
         self.session = session
         workerinfo = getinfodict()

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -919,6 +919,28 @@ class TestWarnings:
 
 
 class TestNodeFailure:
+    @pytest.mark.parametrize("returncode", [0, 1])
+    def test_pytest_exit_is_not_reported_as_internal_error(
+        self, pytester: pytest.Pytester, returncode: int
+    ) -> None:
+        f = pytester.makepyfile(
+            f"""
+            import time
+            import pytest
+
+            @pytest.mark.parametrize("i", range(20))
+            def test_me(i):
+                if i == 12:
+                    pytest.exit("Something", {returncode})
+                time.sleep(0.01)
+        """
+        )
+        res = pytester.runpytest(f, "-n4")
+        assert res.ret == returncode
+        assert "INTERNALERROR" not in res.stdout.str()
+        assert "received keyboard-interrupt" not in res.stdout.str()
+        res.stdout.fnmatch_lines(["* _pytest.outcomes.Exit: Something *"])
+
     def test_load_single(self, pytester: pytest.Pytester) -> None:
         f = pytester.makepyfile(
             """


### PR DESCRIPTION
## Summary

- Detect `pytest.exit()` on workers via the `pytest_keyboard_interrupt` hook
- Propagate exit reason and return code to the controller
- Handle graceful worker exit without triggering internal error
- Re-raise `pytest.exit.Exception` in the controller to preserve the requested return code

Fixes #1239

## Changes

**src/xdist/remote.py** (Worker side):
- Added `pytest_keyboard_interrupt` hook in `WorkerInteractor` to detect `pytest.exit.Exception`
- Stores `exitreason` and `exitreturncode` in `workeroutput` when `pytest.exit()` is called

**src/xdist/dsession.py** (Controller side):
- Added `_worker_exit` field to track worker exit via `pytest.exit()`
- In `worker_workerfinished`, checks for exit info and handles gracefully (no crashitem assertion)
- In `pytest_runtestloop`, re-raises `pytest.exit.Exception` to preserve return code

**testing/acceptance_test.py**:
- Added parametrized test for `pytest.exit()` with return codes 0 and 1
- Verifies no INTERNALERROR and correct exit behavior

## Tests

- Ran `pytest testing/acceptance_test.py::TestNodeFailure::test_pytest_exit_is_not_reported_as_internal_error -v` - PASSED
- Ran `pytest testing/acceptance_test.py::TestNodeFailure -v` - All existing tests PASSED

Closes #1239