### PR TITLE
Allow installing git blobs without cloning

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
- [ ] ~~Make sure to include reasonable tests for your change if necessary~~

- [ ] ~~We use [towncrier](https://pypi.python.org/pypi/towncrier) for changelog management, so please add a *news* file into the `changelog` folder~~

I don't think this is really changelog-worthy, but happy to add one if a maintainer thinks it is! Same with a test...

Allows installing
```
pip install https://github.com/pytest-dev/pytest-xdist/archive/refs/heads/master.zip
```
directly and obtaining a correct version from scm. Nicer than `git+` because you don't have to clone the whole repo for it to work.

I've been using this for a year or two in MNE-Python and other repos without issues.